### PR TITLE
Fix 'Bell state' emoticon tutorial url

### DIFF
--- a/community/hello_world/quantum_emoticon.ipynb
+++ b/community/hello_world/quantum_emoticon.ipynb
@@ -57,7 +57,7 @@
     "    8)  =  '01110000101001'\n",
     "    ;)  =  '01110110101001'\n",
     "\n",
-    "Note that these strings differ only on bits 7 and 8. It is therefore only these on which the superposition must be prepared. The superposition will be of the '00' of 8), and the '11' of ;) , and so will be a standard [Bell state](https://github.com/QISKit/qiskit-tutorial/blob/master/2_quantum_information/superposition_and_entanglement.ipynb).\n",
+    "Note that these strings differ only on bits 7 and 8. It is therefore only these on which the superposition must be prepared. The superposition will be of the '00' of 8), and the '11' of ;) , and so will be a standard [Bell state](https://github.com/QISKit/qiskit-tutorial/blob/master/community/terra/qis_intro/entanglement_introduction.ipynb).\n",
     "\n",
     "We'll now implement this."
    ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Changing the 'Bell state' url in the emoticon tutorial. The old path doesn't exist.

