### PR TITLE
Bug Fixing on jupyter notebook example

### DIFF
--- a/qiskit/basics/the_ibmq_provider.ipynb
+++ b/qiskit/basics/the_ibmq_provider.ipynb
@@ -543,7 +543,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "only return backends that are real devices, have more than 10 qubits and are operational"
+    "only return backends that are real devices, have at most 5 qubits and are operational"
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixing cell description on backend filtering example at the_ibmq_provider.ipynb notebook.


### Details and comments


I changed a cell description on the filtering the backends example because it had an inconsistences between the cell description and the source code on cell.

I changed the qubits limit description from "have more than 10 qubits" to "have at most 5 qubits" in order to make sense with the condition in source code at the belowing cell. 

I changed cell description and not source code because below in notebooks, there are examples filtering backends with exactly 5 qubits. So in this way the fix makes the notebook more armonic.
