### PR TITLE
Fixed a misprint in quantum volume tutorial

### DIFF
--- a/qiskit/ignis/quantum_volume.ipynb
+++ b/qiskit/ignis/quantum_volume.ipynb
@@ -333,7 +333,7 @@
    "source": [
     "## Execute on Aer simulator\n",
     "\n",
-    "We can execute the RB sequences either using Qiskit Aer Simulator (with some noise model) or using IBMQ provider, \n",
+    "We can execute the QV sequences either using Qiskit Aer Simulator (with some noise model) or using IBMQ provider, \n",
     "and obtain a list of results **result_list**."
    ]
   },


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed a misprint: "RB sequences" should be "QV sequences"


### Details and comments


