### PR TITLE
Codeowner update for changed aqua folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,16 +6,16 @@ qiskit/* @jaygambetta @ajavadia
 qiskit/aer/* @chriseclectic @jaygambetta @ajavadia
 qiskit/ignis/* @dcmckayibm @jaygambetta @ajavadia
 qiskit/terra/* @nonhermitian @jaygambetta @ajavadia
-qiskit/aqua/* @pistoia @jaygambetta @ajavadia
-qiskit/aqua/*/* @pistoia @jaygambetta @ajavadia
-qiskit/artificial_intelligence/* @pistoia @jaygambetta @ajavadia
-qiskit/artificial_intelligence/*/* @pistoia @jaygambetta @ajavadia
-qiskit/chemistry/* @pistoia @jaygambetta @ajavadia
-qiskit/chemistry/*/* @pistoia @jaygambetta @ajavadia
-qiskit/finance/* @pistoia @jaygambetta @ajavadia
-qiskit/finance/*/* @pistoia @jaygambetta @ajavadia
-qiskit/optimization/* @pistoia @jaygambetta @ajavadia
-qiskit/optimization/*/* @pistoia @jaygambetta @ajavadia
+qiskit/aqua/* @pistoia @jaygambetta
+qiskit/aqua/*/* @pistoia @jaygambetta
+qiskit/artificial_intelligence/* @pistoia @jaygambetta
+qiskit/artificial_intelligence/*/* @pistoia @jaygambetta
+qiskit/chemistry/* @pistoia @jaygambetta
+qiskit/chemistry/*/* @pistoia @jaygambetta
+qiskit/finance/* @pistoia @jaygambetta
+qiskit/finance/*/* @pistoia @jaygambetta
+qiskit/optimization/* @pistoia @jaygambetta
+qiskit/optimization/*/* @pistoia @jaygambetta
 
 community/* @attp @aasfaw @quantumjim @rraymondhp
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,16 @@ qiskit/* @jaygambetta @ajavadia
 qiskit/aer/* @chriseclectic @jaygambetta @ajavadia
 qiskit/ignis/* @dcmckayibm @jaygambetta @ajavadia
 qiskit/terra/* @nonhermitian @jaygambetta @ajavadia
+qiskit/aqua/* @pistoia @jaygambetta @ajavadia
+qiskit/aqua/*/* @pistoia @jaygambetta @ajavadia
+qiskit/artificial_intelligence/* @pistoia @jaygambetta @ajavadia
+qiskit/artificial_intelligence/*/* @pistoia @jaygambetta @ajavadia
+qiskit/chemistry/* @pistoia @jaygambetta @ajavadia
+qiskit/chemistry/*/* @pistoia @jaygambetta @ajavadia
+qiskit/finance/* @pistoia @jaygambetta @ajavadia
+qiskit/finance/*/* @pistoia @jaygambetta @ajavadia
+qiskit/optimization/* @pistoia @jaygambetta @ajavadia
+qiskit/optimization/*/* @pistoia @jaygambetta @ajavadia
 
 community/* @attp @aasfaw @quantumjim @rraymondhp
 
@@ -19,6 +29,22 @@ community/arts/* @attp @aasfaw @quantumjim @rraymondhp
 community/aqua/* @chunfuchen @pistoia @aasfaw
 community/aqua/*/* @chunfuchen @pistoia @aasfaw
 community/aqua/*/*/* @chunfuchen @pistoia @aasfaw
+
+community/artificial_intelligence/* @chunfuchen @pistoia @aasfaw
+community/artificial_intelligence/*/* @chunfuchen @pistoia @aasfaw
+community/artificial_intelligence/*/*/* @chunfuchen @pistoia @aasfaw
+
+community/chemistry/* @chunfuchen @pistoia @aasfaw
+community/chemistry/*/* @chunfuchen @pistoia @aasfaw
+community/chemistry/*/*/* @chunfuchen @pistoia @aasfaw
+
+community/finance/* @chunfuchen @pistoia @aasfaw
+community/finance/*/* @chunfuchen @pistoia @aasfaw
+community/finance/*/*/* @chunfuchen @pistoia @aasfaw
+
+community/optimization/* @chunfuchen @pistoia @aasfaw
+community/optimization/*/* @chunfuchen @pistoia @aasfaw
+community/optimization/*/*/* @chunfuchen @pistoia @aasfaw
 
 community/awards/teach_me_qiskit_2018/* @attp @aasfaw @quantumjim @rraymondhp
 community/awards/teach_me_qiskit_2018/*/* @attp @aasfaw @quantumjim @rraymondhp


### PR DESCRIPTION
Update to CODEOWNERS file for changes to Aqua folders where application folders, such as finance, chemistry etc, have been moved out from being sub-folders of aqua. Separate PRs will follow shortly for tutorial notebook updates.