### PR TITLE
Broken links: Updated to the new location of Aqua tutorials

### DIFF
--- a/qiskit/aqua/artificial_intelligence/index.ipynb
+++ b/qiskit/aqua/artificial_intelligence/index.ipynb
@@ -13,7 +13,7 @@
     "## Contents\n",
     "\n",
     "* [Quantum SVM for Classification](qsvm_kernel_classification.ipynb)\n",
-    "* More examples can be found in [commuity/aqua/artificial_intelligence](../../../community/aqua/artificial_intelligence)"
+    "* More examples can be found in [community/artificial_intelligence](../../../community/artificial_intelligence)"
    ]
   },
   {

--- a/qiskit/aqua/chemistry/index.ipynb
+++ b/qiskit/aqua/chemistry/index.ipynb
@@ -13,7 +13,7 @@
     "* [Howto: declarative approach](declarative_approach.ipynb)\n",
     "* [Howto: programmatic approach](programmatic_approach.ipynb)\n",
     "* [Quantum Chemistry with VQE](dissociation_profile_of_molecule.ipynb) dissociation curve of H<sub>2</sub> and LiH\n",
-    "* More examples can be found in [commuity/aqua/chemistry](../../../community/aqua/chemistry)"
+    "* More examples can be found in [community/chemistry](../../../community/chemistry)"
    ]
   },
   {

--- a/qiskit/aqua/finance/index.ipynb
+++ b/qiskit/aqua/finance/index.ipynb
@@ -13,7 +13,7 @@
     "* [Portfolio Optimization](portfolio_optimization.ipynb)\n",
     "* [European Call Option Pricing](european_call_option_pricing.ipynb)\n",
     "* [Fixed-Income Asset Pricing](fixed_income_pricing.ipynb)\n",
-    "* More examples can be found in [commuity/aqua/finance](../../../community/aqua/finance)"
+    "* More examples can be found in [community/finance](../../../community/finance)"
    ]
   },
   {

--- a/qiskit/aqua/optimization/index.ipynb
+++ b/qiskit/aqua/optimization/index.ipynb
@@ -13,7 +13,7 @@
     "## Contents\n",
     "\n",
     "* [Solve classical optimization](maxcut_and_tsp.ipynb) (MaxCut and Traveling Salesman Problem)\n",
-    "* More examples can be found in [commuity/aqua/optimization](../../../community/aqua/optimization)"
+    "* More examples can be found in [community/optimization](../../../community/optimization)"
    ]
   },
   {


### PR DESCRIPTION
After the Aqua 0.5 community update, the paths to the the following tutorials need to be updated:
- Qiskit Aqua Artificial Intelligence Tutorials
- Qiskit Chemistry Tutorials
- Qiskit FInance Tutorials
- Qiskit Optimization Tutorials