### PR TITLE
update awards codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,14 +36,7 @@ community/optimization/* @chunfuchen @pistoia @aasfaw
 community/optimization/*/* @chunfuchen @pistoia @aasfaw
 community/optimization/*/*/* @chunfuchen @pistoia @aasfaw
 
-community/awards/teach_me_qiskit_2018/* @attp @aasfaw @quantumjim @rraymondhp
-community/awards/teach_me_qiskit_2018/*/* @attp @aasfaw @quantumjim @rraymondhp
-
-community/awards/teach_me_quantum_2018/* @attp @aasfaw @quantumjim @rraymondhp
-community/awards/teach_me_quantum_2018/*/* @attp @aasfaw @quantumjim @rraymondhp
-community/awards/teach_me_quantum_2018/*/*/* @attp @aasfaw @quantumjim @rraymondhp
-community/awards/teach_me_quantum_2018/*/*/*/* @attp @aasfaw @quantumjim @rraymondhp
-community/awards/teach_me_quantum_2018/*/*/*/*/* @attp @aasfaw @quantumjim @rraymondhp
+community/awards/** @attp @aasfaw @quantumjim @rraymondhp
 
 community/games/* @attp @aasfaw @quantumjim @rraymondhp
 community/games/*/* @attp @aasfaw @quantumjim @rraymondhp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@ community/optimization/* @chunfuchen @pistoia @aasfaw
 community/optimization/*/* @chunfuchen @pistoia @aasfaw
 community/optimization/*/*/* @chunfuchen @pistoia @aasfaw
 
-community/awards/** @attp @aasfaw @quantumjim @rraymondhp
+community/awards/**/* @attp @aasfaw @quantumjim @rraymondhp
 
 community/games/* @attp @aasfaw @quantumjim @rraymondhp
 community/games/*/* @attp @aasfaw @quantumjim @rraymondhp


### PR DESCRIPTION
add a more compact subdirectory match for the community/awards folder using two asterisks

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
add a more compact subdirectory match for the community/awards folder using two asterisks

instead of doing several /*/*/*, just do one /** whenever deeper access to subdirs is required.


### Details and comments


