### PR TITLE
Update CODEOWNERS with Aqua and its domains

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,13 @@
 
 # Codeowners for individual folders
 qiskit/* @jaygambetta @ajavadia
+
+qiskit/aqua/* @jaygambetta @pistoia
+qiskit/artificial_intelligence/* @jaygambetta @pistoia
+qiskit/chemistry/* @jaygambetta @pistoia
+qiskit/finance/* @jaygambetta @pistoia
+qiskit/optimization/* @jaygambetta @pistoia
+
 qiskit/aer/* @chriseclectic @jaygambetta @ajavadia
 qiskit/ignis/* @dcmckayibm @jaygambetta @ajavadia
 qiskit/terra/* @nonhermitian @jaygambetta @ajavadia


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Added @jaygambetta and @pistoia as codeowners of the following folders and their subfolders as per conversation with @jaygambetta
- `qiskit/aqua`
- `qiskit/artificial_intelligence`
- `qiskit/chemistry`
- `qiskit/finance`
- `qiskit/optimization`


### Details and comments
Added @pistoia as code co-owner of the Aqua tutorials (both the general Aqua tutorials and the domain-specific ones)

