### PR TITLE
Update the creating a provider notebook

### DIFF
--- a/qiskit/advanced/terra/creating_a_provider.ipynb
+++ b/qiskit/advanced/terra/creating_a_provider.ipynb
@@ -170,6 +170,7 @@
     "            'url': 'http://www.i_love_hadamard.com',\n",
     "            'simulator': True,\n",
     "            'local': True,\n",
+    "            'coupling_map': None,\n",
     "            'description': 'Simulates only Hadamard gates',\n",
     "            'basis_gates': ['h', 'x'],  # basis_gates must contain at least two gates\n",
     "            'memory': True,\n",
@@ -237,7 +238,7 @@
     "                'success': True, \n",
     "                'shots': shots, \n",
     "                'data': {'counts': formatted_counts},\n",
-    "                'header': circuit.header.as_dict()\n",
+    "                'header': circuit.header.to_dict()\n",
     "            })\n",
     "                        \n",
     "        hadamard_job._result = Result.from_dict({\n",
@@ -270,7 +271,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'0000': 256, '0010': 256, '0100': 256, '0110': 256}\n"
+      "{'0110': 256, '0000': 256, '0010': 256, '0100': 256}\n"
      ]
     }
    ],
@@ -351,9 +352,9 @@
      "output_type": "stream",
      "text": [
       "Hadamard simulator:\n",
-      "{'0000': 256, '0010': 256, '0100': 256, '0110': 256}\n",
+      "{'0110': 256, '0000': 256, '0010': 256, '0100': 256}\n",
       "Aer simulator:\n",
-      "{'0000': 270, '0010': 263, '0100': 253, '0110': 238}\n"
+      "{'0110': 263, '0000': 247, '0010': 270, '0100': 244}\n"
      ]
     }
    ],
@@ -376,6 +377,13 @@
     "print('Aer simulator:')\n",
     "print(aer_result.get_counts(qc))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -395,7 +403,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The creating a provider notebook was a bit out of date. The primary
issue was that the backend configuration was missing a mandatory field,
the coupling_map. This field is added and set to None, which is the
proper value for the example here. It was also using a deprecated
function, which is also updated here.

### Details and comments