### PR TITLE
fix the missing ')'

### DIFF
--- a/qiskit/fundamentals/1_getting_started_with_qiskit.ipynb
+++ b/qiskit/fundamentals/1_getting_started_with_qiskit.ipynb
@@ -86,7 +86,7 @@
     "$$|\\psi\\rangle = \\left(|000\\rangle+|111\\rangle\\right)/\\sqrt{2}.$$\n",
     "\n",
     "To create such a state, we start with a three-qubit quantum register. By default, each qubit in the register is initialized to $|0\\rangle$. To make the GHZ state, we apply the following gates:\n",
-    "* A Hadamard gate $H$ on qubit 0, which puts it into the superposition state $\\left(|0\\rangle+|1\\rangle\\right/\\sqrt{2}$.\n",
+    "* A Hadamard gate $H$ on qubit 0, which puts it into the superposition state $\\left(|0\\rangle+|1\\rangle\\right)/\\sqrt{2}$.\n",
     "* A controlled-Not operation ($C_{X}$) between qubit 0 and qubit 1.\n",
     "* A controlled-Not operation between qubit 0 and qubit 2.\n",
     "\n",


### PR DESCRIPTION


fix the missing ')' in qiskit/fundamentals/1_getting_started_with_qiskit.ipynb

![image](https://user-images.githubusercontent.com/26158289/63356722-dce6bd80-c39a-11e9-86f2-00c3a69cbe49.png)





