### PR TITLE
Remove invalid stestr config

### DIFF
--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,2 +1,0 @@
-[DEFAULT]
-test_path=./utils/test


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In older versions of the tutorials repo there was a unit testing harness
that would generate a test case based on executing each tutorial
successfully without any errors. When that testing harness exited stestr
could be used to parallelize the execution of the notebook tests to make
it faster. However, in recent refactors the testing harness has been
removed and instead we rely on sphinx builds to validate the notebooks
work. The .stestr.conf was not removed as part of that, so this commit
takes care of that oversight and deletes the unused test runner
configuration file.

### Details and comments

Fixes #930