### PR TITLE
Update 1_getting_started_with_qiskit.ipynb

### DIFF
--- a/tutorials/circuits/1_getting_started_with_qiskit.ipynb
+++ b/tutorials/circuits/1_getting_started_with_qiskit.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Getting Started with Qiskit\n",
     "\n",
-    "Here, we provide an overview of working with Qiskit.  The fundamental package of Qiskit is Terra that provides the basic building blocks necessary to program quantum computers. The fundamental unit of Qiskit is the [**quantum circuit**](https://en.wikipedia.org/wiki/Quantum_circuit). A basic workflow using Qiskit consists of two stages: **Build** and **Execute**. **Build** allows you to make different quantum circuits that represent the problem you are solving, and **Execute** that allows you to run them on different backends.  After the jobs have been run, the data is collected and postprocessed depending on the desired output."
+    "Here, we provide an overview of working with Qiskit.  The fundamental package of Qiskit is Terra that provides the basic building blocks necessary to program quantum computers. The fundamental unit of Qiskit is the [quantum circuit](https://en.wikipedia.org/wiki/Quantum_circuit). A basic workflow using Qiskit consists of two stages: **Build** and **Execute**. **Build** allows you to make different quantum circuits that represent the problem you are solving, and **Execute** that allows you to run them on different backends.  After the jobs have been run, the data is collected and postprocessed depending on the desired output."
    ]
   },
   {
@@ -61,9 +61,9 @@
     "$$|\\psi\\rangle = \\left(|000\\rangle+|111\\rangle\\right)/\\sqrt{2}.$$\n",
     "\n",
     "To create such a state, we start with a three-qubit quantum register. By default, each qubit in the register is initialized to $|0\\rangle$. To make the GHZ state, we apply the following gates:\n",
-    "* A Hadamard gate $H$ on qubit 0, which puts it into the superposition state $\\left(|0\\rangle+|1\\rangle\\right)/\\sqrt{2}$.\n",
-    "* A controlled-Not operation ($C_{X}$) between qubit 0 and qubit 1.\n",
-    "* A controlled-Not operation between qubit 0 and qubit 2.\n",
+    "- A Hadamard gate $H$ on qubit 0, which puts it into the superposition state $\\left(|0\\rangle+|1\\rangle\\right)/\\sqrt{2}$.\n",
+    "- A controlled-Not operation ($C_{X}$) between qubit 0 and qubit 1.\n",
+    "- A controlled-Not operation between qubit 0 and qubit 2.\n",
     "\n",
     "On an ideal quantum computer, the state produced by running this circuit would be the GHZ state above.\n",
     "\n",


### PR DESCRIPTION
fix markdown syntax to resolve #975

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.


### Summary
Updated markdown syntax for the comments listed in #975 


### Details and comments
Updates made:
1. Removed '**' before and after "qiskit circuit" link.
2. Replaced '*' with '-' for bulleted items under the statement "To make the GHZ state, we apply the following gates:".

