### PR TITLE
Use metapackage visualization extra instead of terra's

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ steps:
     source /tmp/docs_build/bin/activate
     pip install -U qiskit jupyter sphinx nbsphinx sphinx_rtd_theme
     pip install 'matplotlib<3.3'
-    pip install -U qiskit-terra[visualization] cvxpy
+    pip install -U qiskit[visualization] cvxpy
     sudo apt-get install -y pandoc graphviz
   displayName: 'Install dependencies'
 - bash: |


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now we're in a weird place because there is a terra release live
that has some breaking changes for ignis and aqua. This shouldn't be a
blocker for changes in tutorials because we should be using the
latest metapackage release but because we install visualization
dependencies using qiskit-terra[visualization] we're pulling in the
latest terra release which hasn't been included in a metapackage yet.
This causes the aqua tutorials to fail because they require the latest
release. This commit fixes this by using qiskit[visualization] which
won't pull in a terra version that isn't part of known working
metapackage.

### Details and comments


