### PR TITLE
removing backend properties as a dictionary

### DIFF
--- a/tutorials/circuits_advanced/4_transpiler_passes_and_passmanager.ipynb
+++ b/tutorials/circuits_advanced/4_transpiler_passes_and_passmanager.ipynb
@@ -374,8 +374,7 @@
     "import math\n",
     "from qiskit.test.mock import FakeTokyo\n",
     "\n",
-    "backend = FakeTokyo()     # mimics the tokyo device in terms of coupling map and basis gates\n",
-    "backend.properties = {}   # remove fake properties"
+    "backend = FakeTokyo()     # mimics the tokyo device in terms of coupling map and basis gates"
    ]
   },
   {


### PR DESCRIPTION
`backend.properties` should be a `BackendProperties` class. The transpiler assumes that.