### PR TITLE
Fix statevector snapshot access in MPS tutorial

### DIFF
--- a/tutorials/simulators/7_matrix_product_state_method.ipynb
+++ b/tutorials/simulators/7_matrix_product_state_method.ipynb
@@ -65,7 +65,7 @@
     {
      "data": {
       "text/plain": [
-       "{'00': 520, '11': 504}"
+       "{'11': 532, '00': 492}"
       ]
      },
      "execution_count": 1,
@@ -134,7 +134,7 @@
     {
      "data": {
       "text/plain": [
-       "[[(0.7071067811865475+0j), 0j, 0j, (0.7071067811865475+0j)]]"
+       "[(0.7071067811865475+0j), 0j, 0j, (0.7071067811865475+0j)]"
       ]
      },
      "execution_count": 3,
@@ -154,11 +154,9 @@
     "# Execute\n",
     "job_sim = execute([circ], QasmSimulator(), backend_options=backend_opts_mps)\n",
     "result = job_sim.result()\n",
-    "res = result.results\n",
     "\n",
     "#print the state vector\n",
-    "statevector = res[0].data.snapshots.statevector\n",
-    "statevector['my_sv']"
+    "result.data()['snapshots']['statevector']['my_sv'][0]"
    ]
   },
   {
@@ -174,7 +172,7 @@
     {
      "data": {
       "text/plain": [
-       "{'00': 517, '11': 507}"
+       "{'11': 516, '00': 508}"
       ]
      },
      "execution_count": 4,
@@ -210,14 +208,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time taken: 2.162709951400757 sec\n"
+      "Time taken: 0.677933931350708 sec\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'11111111111111111111111111111111111111111111111111': 486,\n",
-       " '00000000000000000000000000000000000000000000000000': 538}"
+       "{'11111111111111111111111111111111111111111111111111': 543,\n",
+       " '00000000000000000000000000000000000000000000000000': 481}"
       ]
      },
      "execution_count": 5,
@@ -258,8 +256,8 @@
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>None</td></tr><tr><td>Terra</td><td>0.14.0</td></tr><tr><td>Aer</td><td>0.6.0</td></tr><tr><td>Ignis</td><td>None</td></tr><tr><td>Aqua</td><td>None</td></tr><tr><td>IBM Q Provider</td><td>0.6.1</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.7.7 (default, Mar 26 2020, 10:32:53) \n",
-       "[Clang 4.0.1 (tags/RELEASE_401/final)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>4</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Tue Apr 28 13:43:42 2020 EDT</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.19.6</td></tr><tr><td>Terra</td><td>0.14.2</td></tr><tr><td>Aer</td><td>0.5.2</td></tr><tr><td>Ignis</td><td>0.3.3</td></tr><tr><td>Aqua</td><td>0.7.3</td></tr><tr><td>IBM Q Provider</td><td>0.7.2</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.8.5 (default, Jul 27 2020, 08:42:51) \n",
+       "[GCC 10.1.0]</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>32</td></tr><tr><td>Memory (Gb)</td><td>125.72603988647461</td></tr><tr><td colspan='2'>Mon Aug 10 13:36:15 2020 EDT</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -311,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The statevector snapshot tutorial access done in the MPS tutorials was
relying on internal implementation details (inherited from marshmallow)
for how it was accessing the statevector for printing. This causes an
issue when qiskit 0.20.0 is used because there is no marshmallow anymore.
Instead of relying on the nested internal object attr access that was
used before this uses the supported data() method to return a dict of
snapshots and pull the statevector from there. This should be support
for all versions of qiskit-terra, not just <0.15.0 and is the documented
method for retrieving snapshots.

This is the last thing needed to unblock Qiskit/qiskit#998 and finally
relaese qiskit 0.20.0.

### Details and comments