### PR TITLE
Resolved deprecation warnings in Converters for Quadratic Programs no…

### DIFF
--- a/tutorials/optimization/2_converters_for_quadratic_programs.ipynb
+++ b/tutorials/optimization/2_converters_for_quadratic_programs.ipynb
@@ -62,7 +62,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -109,7 +111,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Call `encode` method of `InequalityToEqualityConverter` to convert."
+    "Call `convert` method of `InequalityToEqualityConverter`."
    ]
   },
   {
@@ -124,7 +126,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -159,7 +163,7 @@
    ],
    "source": [
     "ineq2eq = InequalityToEquality()\n",
-    "qp_eq = ineq2eq.encode(qp)\n",
+    "qp_eq = ineq2eq.convert(qp)\n",
     "print(qp_eq.export_as_lp_string())"
    ]
   },
@@ -189,7 +193,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -230,7 +236,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Call `encode` method of `IntegerToBinary` to convert."
+    "Call `convert` method of `IntegerToBinary`."
    ]
   },
   {
@@ -245,7 +251,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -286,7 +294,7 @@
    ],
    "source": [
     "int2bin = IntegerToBinary()\n",
-    "qp_eq_bin = int2bin.encode(qp_eq)\n",
+    "qp_eq_bin = int2bin.convert(qp_eq)\n",
     "print(qp_eq_bin.export_as_lp_string())"
    ]
   },
@@ -324,7 +332,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -371,7 +381,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Call encode method of `LinearEqualityToPenalty` to convert."
+    "Call `convert` method of `LinearEqualityToPenalty`."
    ]
   },
   {
@@ -386,7 +396,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -397,40 +409,33 @@
       "\\Problem name: CPLEX\n",
       "\n",
       "Maximize\n",
-      " obj: 1600002 x + 1600001 y + 1600001 z@0 + 3200002 z@1 + 6400004 z@2\n",
-      "      + 1000000 xyz_leq@int_slack@0 + 2000000 xyz_leq@int_slack@1\n",
-      "      + 2000000 xyz_leq@int_slack@2 - 600000 xyz_geq@int_slack@0\n",
-      "      - 1200000 xyz_geq@int_slack@1 - 1800000 xyz_geq@int_slack@2 + [\n",
-      "      - 400000 x^2 - 800000 x*y - 800000 x*z@0 - 1600000 x*z@1 - 3200000 x*z@2\n",
-      "      - 400000 x*xyz_leq@int_slack@0 - 800000 x*xyz_leq@int_slack@1\n",
-      "      - 800000 x*xyz_leq@int_slack@2 + 400000 x*xyz_geq@int_slack@0\n",
-      "      + 800000 x*xyz_geq@int_slack@1 + 1200000 x*xyz_geq@int_slack@2\n",
-      "      - 400000 y^2 - 800000 y*z@0 - 1600000 y*z@1 - 3200000 y*z@2\n",
-      "      - 400000 y*xyz_leq@int_slack@0 - 800000 y*xyz_leq@int_slack@1\n",
-      "      - 800000 y*xyz_leq@int_slack@2 + 400000 y*xyz_geq@int_slack@0\n",
-      "      + 800000 y*xyz_geq@int_slack@1 + 1200000 y*xyz_geq@int_slack@2\n",
-      "      - 400000 z@0^2 - 1600000 z@0*z@1 - 3200000 z@0*z@2\n",
-      "      - 400000 z@0*xyz_leq@int_slack@0 - 800000 z@0*xyz_leq@int_slack@1\n",
-      "      - 800000 z@0*xyz_leq@int_slack@2 + 400000 z@0*xyz_geq@int_slack@0\n",
-      "      + 800000 z@0*xyz_geq@int_slack@1 + 1200000 z@0*xyz_geq@int_slack@2\n",
-      "      - 1600000 z@1^2 - 6400000 z@1*z@2 - 800000 z@1*xyz_leq@int_slack@0\n",
-      "      - 1600000 z@1*xyz_leq@int_slack@1 - 1600000 z@1*xyz_leq@int_slack@2\n",
-      "      + 800000 z@1*xyz_geq@int_slack@0 + 1600000 z@1*xyz_geq@int_slack@1\n",
-      "      + 2400000 z@1*xyz_geq@int_slack@2 - 6400000 z@2^2\n",
-      "      - 1600000 z@2*xyz_leq@int_slack@0 - 3200000 z@2*xyz_leq@int_slack@1\n",
-      "      - 3200000 z@2*xyz_leq@int_slack@2 + 1600000 z@2*xyz_geq@int_slack@0\n",
-      "      + 3200000 z@2*xyz_geq@int_slack@1 + 4800000 z@2*xyz_geq@int_slack@2\n",
-      "      - 200000 xyz_leq@int_slack@0^2\n",
-      "      - 800000 xyz_leq@int_slack@0*xyz_leq@int_slack@1\n",
-      "      - 800000 xyz_leq@int_slack@0*xyz_leq@int_slack@2\n",
-      "      - 800000 xyz_leq@int_slack@1^2\n",
-      "      - 1600000 xyz_leq@int_slack@1*xyz_leq@int_slack@2\n",
-      "      - 800000 xyz_leq@int_slack@2^2 - 200000 xyz_geq@int_slack@0^2\n",
-      "      - 800000 xyz_geq@int_slack@0*xyz_geq@int_slack@1\n",
-      "      - 1200000 xyz_geq@int_slack@0*xyz_geq@int_slack@2\n",
-      "      - 800000 xyz_geq@int_slack@1^2\n",
-      "      - 2400000 xyz_geq@int_slack@1*xyz_geq@int_slack@2\n",
-      "      - 1800000 xyz_geq@int_slack@2^2 ]/2 -3400000\n",
+      " obj: 178 x + 177 y + 177 z@0 + 354 z@1 + 708 z@2 + 110 xyz_leq@int_slack@0\n",
+      "      + 220 xyz_leq@int_slack@1 + 220 xyz_leq@int_slack@2\n",
+      "      - 66 xyz_geq@int_slack@0 - 132 xyz_geq@int_slack@1\n",
+      "      - 198 xyz_geq@int_slack@2 + [ - 44 x^2 - 88 x*y - 88 x*z@0 - 176 x*z@1\n",
+      "      - 352 x*z@2 - 44 x*xyz_leq@int_slack@0 - 88 x*xyz_leq@int_slack@1\n",
+      "      - 88 x*xyz_leq@int_slack@2 + 44 x*xyz_geq@int_slack@0\n",
+      "      + 88 x*xyz_geq@int_slack@1 + 132 x*xyz_geq@int_slack@2 - 44 y^2 - 88 y*z@0\n",
+      "      - 176 y*z@1 - 352 y*z@2 - 44 y*xyz_leq@int_slack@0\n",
+      "      - 88 y*xyz_leq@int_slack@1 - 88 y*xyz_leq@int_slack@2\n",
+      "      + 44 y*xyz_geq@int_slack@0 + 88 y*xyz_geq@int_slack@1\n",
+      "      + 132 y*xyz_geq@int_slack@2 - 44 z@0^2 - 176 z@0*z@1 - 352 z@0*z@2\n",
+      "      - 44 z@0*xyz_leq@int_slack@0 - 88 z@0*xyz_leq@int_slack@1\n",
+      "      - 88 z@0*xyz_leq@int_slack@2 + 44 z@0*xyz_geq@int_slack@0\n",
+      "      + 88 z@0*xyz_geq@int_slack@1 + 132 z@0*xyz_geq@int_slack@2 - 176 z@1^2\n",
+      "      - 704 z@1*z@2 - 88 z@1*xyz_leq@int_slack@0 - 176 z@1*xyz_leq@int_slack@1\n",
+      "      - 176 z@1*xyz_leq@int_slack@2 + 88 z@1*xyz_geq@int_slack@0\n",
+      "      + 176 z@1*xyz_geq@int_slack@1 + 264 z@1*xyz_geq@int_slack@2 - 704 z@2^2\n",
+      "      - 176 z@2*xyz_leq@int_slack@0 - 352 z@2*xyz_leq@int_slack@1\n",
+      "      - 352 z@2*xyz_leq@int_slack@2 + 176 z@2*xyz_geq@int_slack@0\n",
+      "      + 352 z@2*xyz_geq@int_slack@1 + 528 z@2*xyz_geq@int_slack@2\n",
+      "      - 22 xyz_leq@int_slack@0^2 - 88 xyz_leq@int_slack@0*xyz_leq@int_slack@1\n",
+      "      - 88 xyz_leq@int_slack@0*xyz_leq@int_slack@2 - 88 xyz_leq@int_slack@1^2\n",
+      "      - 176 xyz_leq@int_slack@1*xyz_leq@int_slack@2 - 88 xyz_leq@int_slack@2^2\n",
+      "      - 22 xyz_geq@int_slack@0^2 - 88 xyz_geq@int_slack@0*xyz_geq@int_slack@1\n",
+      "      - 132 xyz_geq@int_slack@0*xyz_geq@int_slack@2 - 88 xyz_geq@int_slack@1^2\n",
+      "      - 264 xyz_geq@int_slack@1*xyz_geq@int_slack@2 - 198 xyz_geq@int_slack@2^2\n",
+      "      ]/2 -374\n",
       "Subject To\n",
       "\n",
       "Bounds\n",
@@ -456,7 +461,7 @@
    ],
    "source": [
     "lineq2penalty = LinearEqualityToPenalty()\n",
-    "qubo = lineq2penalty.encode(qp_eq_bin)\n",
+    "qubo = lineq2penalty.convert(qp_eq_bin)\n",
     "print(qubo.export_as_lp_string())"
    ]
   },
@@ -483,8 +488,8 @@
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.19.6</td></tr><tr><td>Terra</td><td>0.14.2</td></tr><tr><td>Aer</td><td>0.5.2</td></tr><tr><td>Ignis</td><td>0.3.3</td></tr><tr><td>Aqua</td><td>0.7.3</td></tr><tr><td>IBM Q Provider</td><td>0.7.2</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.7.7 (default, May  6 2020, 04:59:01) \n",
-       "[Clang 4.0.1 (tags/RELEASE_401/final)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>4</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Fri Jul 10 15:15:34 2020 EDT</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>0.20.0</td></tr><tr><td>Terra</td><td>0.15.1</td></tr><tr><td>Aer</td><td>0.6.1</td></tr><tr><td>Ignis</td><td>0.4.0</td></tr><tr><td>Aqua</td><td>0.7.5</td></tr><tr><td>IBM Q Provider</td><td>0.8.0</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.8.5 | packaged by conda-forge | (default, Jul 31 2020, 02:39:48) \n",
+       "[GCC 7.5.0]</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>4</td></tr><tr><td>Memory (Gb)</td><td>30.820919036865234</td></tr><tr><td colspan='2'>Wed Aug 12 11:53:21 2020 EDT</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -536,7 +541,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
…tebook

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Resolved deprecation warnings in issue #1003 related to changes in qiskit-aqua v0.7.4 that were appearing in the Converters for Quadratic Programs tutorial notebook `2_converters_for_quadratic_programs.ipynb`.

### Details and comments

Deprecated method was `qiskit.optimization.converters.QuadraticProgramConverter.encode()`, which was replaced with the `convert()` method.

