### PR TITLE
Fix a typo in the summary of quantum operations tutorial notebook

### DIFF
--- a/tutorials/circuits/3_summary_of_quantum_operations.ipynb
+++ b/tutorials/circuits/3_summary_of_quantum_operations.ipynb
@@ -1002,7 +1002,7 @@
     "\\begin{pmatrix}\n",
     "1 & 0\\\\\n",
     "0 & e^{-i \\pi/4}\n",
-    "\\end{pmatrix}= u1(-pi/4)\n",
+    "\\end{pmatrix}= u1(-\\pi/4)\n",
     "$$"
    ]
   },
@@ -3162,7 +3162,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.2"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixed a typo in the circuit tutorial notebook: 3_summary_of_quantum_operations.ipynb.

### Details and comments

To have consistency in the symbols used in the mathematical description of the quantum operators, a typo in the mathematical expression written in LaTeX was corrected.
