### PR TITLE
Tutorials (Pulse Scheduler): fix header levels

### DIFF
--- a/tutorials/pulse/6_pulse_scheduler.ipynb
+++ b/tutorials/pulse/6_pulse_scheduler.ipynb
@@ -352,7 +352,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Scheduler methods\n",
+    "## Scheduler methods\n",
     "\n",
     "The scheduler can follow multiple routines. By default, it follows an _as late as possible_ (ALAP) rule. Another scheduling method is _as soon as possible_, (ASAP). For both methods, the output schedule is minimal: in the longest-duration operation path of the input circuit, the start time of each operation is the end time of the proceeding operation. The methods determine how to schedule operations outside that longest path.\n",
     "\n",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Demotes heading level of ``Scheduler Methods`` section.


### Details and comments
Fix issue where "Scheduler Methods" would show up as a top-level header in the Pulse Tutorials on https://qiskit.org/documentation/tutorials/pulse/.

Current Pulse Tutorial sidebar: 
![image](https://user-images.githubusercontent.com/10198051/96786997-09430300-13bf-11eb-868c-7e268332a421.png)

``Scheduler Methods`` should be a subheading of ``Using the Scheduler``.
