### PR TITLE
Fixed typo in Electronic Structure chemistry tutorial.

### DIFF
--- a/tutorials/chemistry/01_electronic_structure.ipynb
+++ b/tutorials/chemistry/01_electronic_structure.ipynb
@@ -19,7 +19,7 @@
     "\\mathcal{H} = - \\sum_I \\frac{\\nabla_{R_I}^2}{M_I} - \\sum_i \\frac{\\nabla_{r_i}^2}{m_e} - \\sum_I\\sum_i  \\frac{Z_I e^2}{|R_I-r_i|} + \\sum_i \\sum_{j>i} \\frac{e^2}{|r_i-r_j|} + \\sum_I\\sum_{J>I} \\frac{Z_I Z_J e^2}{|R_I-R_J|}\n",
     "$$\n",
     "\n",
-    "Because the nuclei are much heavier than the electrons they do not move on the same time scale and therefore, the behavior of nuclei and electronc can be decoupled. This is the Born-Oppenheimer approximation.\n",
+    "Because the nuclei are much heavier than the electrons they do not move on the same time scale and therefore, the behavior of nuclei and electrons can be decoupled. This is the Born-Oppenheimer approximation.\n",
     "\n",
     "Therefore, one can first tackle the electronic problem with nuclear coordinate entering only as parameters. The energy levels of the electrons in the molecule can be found by solving the non-relativistic time independant Schroedinger equation,\n",
     "\n",
@@ -375,7 +375,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I fixed the typo in the first paragraph of the chemistry tutorial 01_electronic_structure. Specifically, I changed "electronc" to "electrons".

### Details and comments
When I committed this change, I also accidentally changed the python version documented. I hope that is okay.

