### PR TITLE
Bump cell timeout in sphinx config

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -73,7 +73,7 @@ html_sourcelink_suffix = ''
 exclude_patterns = ['*.ipynb', '_build', 'legacy_tutorials',
                     '**.ipynb_checkpoints']
 
-nbsphinx_timeout = 180
+nbsphinx_timeout = 240
 nbsphinx_execute = 'always'
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'png', 'pdf'}",

--- a/conf.py
+++ b/conf.py
@@ -73,7 +73,8 @@ html_sourcelink_suffix = ''
 exclude_patterns = ['*.ipynb', '_build', 'legacy_tutorials',
                     '**.ipynb_checkpoints']
 
-nbsphinx_timeout = 240
+cell_timeout = os.getenv('QISKIT_CELL_TIMEOUT', 180)
+nbsphinx_timeout = cell_timeout
 nbsphinx_execute = 'always'
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'png', 'pdf'}",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `07_asian_barrier_spread_pricing` tutorial is quite slow and often
times out in CI because running the simulation takes very close to 3
minutes in the fastest case. But, the performance of the CI nodes is
quite variable since they run on virtual machines in azure's public
cloud. So many jobs fail randomly because of timeouts on that notebook.
This commit attempts to fix this by bumping the timeout 60 seconds which
hopefully will give us enough slack time in the job to handle slow CI
nodes.


### Details and comments


