### PR TITLE
Add missing int cast for QISKIT_CELL_TIMEOUT

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -73,7 +73,7 @@ html_sourcelink_suffix = ''
 exclude_patterns = ['*.ipynb', '_build', 'legacy_tutorials',
                     '**.ipynb_checkpoints']
 
-cell_timeout = os.getenv('QISKIT_CELL_TIMEOUT', 180)
+cell_timeout = int(os.getenv('QISKIT_CELL_TIMEOUT', 180))
 nbsphinx_timeout = cell_timeout
 nbsphinx_execute = 'always'
 nbsphinx_execute_arguments = [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1091 we added a new env var to enable downstream CI to adjust the
per cell timeout to make things more reliable in variable performance
environments. But in that PR we neglected to cast the value of the env
var, which is always a string, to an int. This commit fixes that
oversight so the new env var is actually usable.

### Details and comments