### PR TITLE
pin jax versions to load cvxpy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,7 @@ steps:
     pip install -c constraints.txt 'matplotlib<3.3'
     pip install -c constraints.txt -U qiskit[visualization] cvxpy
     pip install -c constraints.txt pyscf
+    pip install -U jax==0.2.9 jaxlib==0.1.59
     sudo apt-get install -y pandoc graphviz
   displayName: 'Install dependencies'
 - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,11 +36,11 @@ steps:
     python -m pip install --upgrade pip setuptools wheel virtualenv
     virtualenv /tmp/docs_build
     source /tmp/docs_build/bin/activate
+    pip install -U jax==0.2.9 jaxlib==0.1.59
     pip install -c constraints.txt -U qiskit jupyter sphinx nbsphinx sphinx_rtd_theme
     pip install -c constraints.txt 'matplotlib<3.3'
     pip install -c constraints.txt -U qiskit[visualization] cvxpy
     pip install -c constraints.txt pyscf
-    pip install -U jax==0.2.9 jaxlib==0.1.59
     sudo apt-get install -y pandoc graphviz
   displayName: 'Install dependencies'
 - bash: |


### PR DESCRIPTION
See: https://github.com/Qiskit/qiskit-aqua/pull/1524

Looks like some installs break the import of others.  Try the fix from the above PR