### PR TITLE
Remove numpy cap from tutorials job

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,2 @@
 docplex==2.15.194
 cvxpy<1.1.8
-numpy<1.20.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the release of numpy 1.20.0 there was a deprecation of several
aliased types that qiskit was relying on in releases prior to Qiskit
0.23.5. This was causing issues in CI jobs because it would flood output
with deprecation warnings from numpy whenever qiskit used these
deprecated aliases in numpy. To workaround this issues in #1127 we
pinned the numpy and cvxpy versions to use an older version to avoid
these deprecation warnings. However, since the release of Qiskit 0.23.5
the deprecated numpy usage in Qiskit has been updated so the warnings
are no longer a problem. This commit removes the numpy pin because it
appears to be interefering with other dependencies blocking CI.

### Details and comments


