### PR TITLE
Pin decorator version for CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
 docplex==2.15.194
 cvxpy<1.1.8
+decorator==4.4.2


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The recent release of decorator 5.0.0 earlier today are causing CI
failures because of an internal incompatibility with the random state
decorator networkx is using for random_gnp_graph() function and these
new decorator versions. To unblock CI until either networkx or decorator
fixes the issue this commit pins the version of decorator we install via
the constraints file to the last known working version.


### Details and comments


