### PR TITLE
Fix: Remove duplicated circuit visualizations

### DIFF
--- a/tutorials/circuits/01_circuit_basics.ipynb
+++ b/tutorials/circuits/01_circuit_basics.ipynb
@@ -21,9 +21,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from qiskit import QuantumCircuit\n",
-    "\n",
-    "%matplotlib inline"
+    "from qiskit import QuantumCircuit"
    ]
   },
   {

--- a/tutorials/circuits/1_getting_started_with_qiskit.ipynb
+++ b/tutorials/circuits/1_getting_started_with_qiskit.ipynb
@@ -21,8 +21,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from qiskit import *\n",
-    "%matplotlib inline"
+    "from qiskit import *"
    ]
   },
   {

--- a/tutorials/circuits/3_summary_of_quantum_operations.ipynb
+++ b/tutorials/circuits/3_summary_of_quantum_operations.ipynb
@@ -40,7 +40,6 @@
    "source": [
     "# Useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "from math import pi"
    ]

--- a/tutorials/circuits_advanced/04_transpiler_passes_and_passmanager.ipynb
+++ b/tutorials/circuits_advanced/04_transpiler_passes_and_passmanager.ipynb
@@ -36,7 +36,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from qiskit import QuantumCircuit\n",
     "from qiskit.compiler import transpile\n",
     "from qiskit.transpiler import PassManager"

--- a/tutorials/finance/02_portfolio_diversification.ipynb
+++ b/tutorials/finance/02_portfolio_diversification.ipynb
@@ -194,8 +194,6 @@
     "import sys\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
-    "\n",
     "# Import Qiskit packages\n",
     "import qiskit \n",
     "from qiskit import Aer\n",

--- a/tutorials/finance/03_european_call_option_pricing.ipynb
+++ b/tutorials/finance/03_european_call_option_pricing.ipynb
@@ -46,7 +46,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "\n",
     "from qiskit import Aer, QuantumCircuit\n",

--- a/tutorials/finance/04_european_put_option_pricing.ipynb
+++ b/tutorials/finance/04_european_put_option_pricing.ipynb
@@ -46,7 +46,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "\n",
     "from qiskit import Aer\n",

--- a/tutorials/finance/05_bull_spread_pricing.ipynb
+++ b/tutorials/finance/05_bull_spread_pricing.ipynb
@@ -48,7 +48,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "\n",
     "from qiskit import Aer\n",

--- a/tutorials/finance/06_basket_option_pricing.ipynb
+++ b/tutorials/finance/06_basket_option_pricing.ipynb
@@ -44,7 +44,6 @@
     "import matplotlib.pyplot as plt\n",
     "from mpl_toolkits.mplot3d import Axes3D\n",
     "from scipy.interpolate import griddata\n",
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "\n",
     "from qiskit import Aer, QuantumRegister, QuantumCircuit, execute, AncillaRegister, transpile\n",

--- a/tutorials/finance/07_asian_barrier_spread_pricing.ipynb
+++ b/tutorials/finance/07_asian_barrier_spread_pricing.ipynb
@@ -53,7 +53,6 @@
     "import matplotlib.pyplot as plt\n",
     "from mpl_toolkits.mplot3d import Axes3D\n",
     "from scipy.interpolate import griddata\n",
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "\n",
     "from qiskit import QuantumRegister, QuantumCircuit, Aer, execute, AncillaRegister, transpile\n",

--- a/tutorials/finance/08_fixed_income_pricing.ipynb
+++ b/tutorials/finance/08_fixed_income_pricing.ipynb
@@ -36,7 +36,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
     "import numpy as np\n",
     "from qiskit import Aer, QuantumCircuit\n",
     "from qiskit.aqua.algorithms import IterativeAmplitudeEstimation\n",

--- a/tutorials/finance/11_time_series.ipynb
+++ b/tutorials/finance/11_time_series.ipynb
@@ -28,7 +28,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from qiskit.finance import QiskitFinanceError\n",
     "from qiskit.finance.data_providers import *\n",
     "import warnings\n",

--- a/tutorials/machine_learning/04_qgans_for_loading_random_distributions.ipynb
+++ b/tutorials/machine_learning/04_qgans_for_loading_random_distributions.ipynb
@@ -31,8 +31,6 @@
     "np.random.seed = seed\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
-    "\n",
     "from qiskit import QuantumRegister, QuantumCircuit, BasicAer\n",
     "from qiskit.circuit.library import TwoLocal, UniformDistribution\n",
     "\n",
@@ -234,8 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {

--- a/tutorials/noise/1_hamiltonian_and_gate_characterization.ipynb
+++ b/tutorials/noise/1_hamiltonian_and_gate_characterization.ipynb
@@ -144,7 +144,6 @@
     }
    ],
    "source": [
-    "%matplotlib inline\n",
     "# Fit the data to an oscillation\n",
     "\n",
     "plt.figure(figsize=(10, 6))\n",
@@ -295,7 +294,6 @@
     }
    ],
    "source": [
-    "%matplotlib inline\n",
     "# Fit the data to an oscillation\n",
     "\n",
     "plt.figure(figsize=(10, 6))\n",
@@ -441,7 +439,6 @@
     }
    ],
    "source": [
-    "%matplotlib inline\n",
     "# Fit the data to an oscillation\n",
     "\n",
     "plt.figure(figsize=(10, 6))\n",
@@ -577,7 +574,6 @@
     }
    ],
    "source": [
-    "%matplotlib inline\n",
     "# Fit the data to an oscillation\n",
     "\n",
     "plt.figure(figsize=(10, 6))\n",
@@ -711,7 +707,6 @@
     }
    ],
    "source": [
-    "%matplotlib inline\n",
     "# Fit the data to an oscillation\n",
     "\n",
     "plt.figure(figsize=(10, 6))\n",

--- a/tutorials/noise/2_relaxation_and_decoherence.ipynb
+++ b/tutorials/noise/2_relaxation_and_decoherence.ipynb
@@ -162,8 +162,6 @@
    "source": [
     "# Fitting T1\n",
     "\n",
-    "%matplotlib inline\n",
-    "\n",
     "plt.figure(figsize=(15, 6))\n",
     "\n",
     "t1_fit = T1Fitter(t1_backend_result, t1_xdata, qubits,\n",
@@ -239,8 +237,6 @@
    "source": [
     "# Fitting T2*\n",
     "\n",
-    "%matplotlib inline\n",
-    "\n",
     "t2star_fit = T2StarFitter(t2star_backend_result, t2star_xdata, qubits,\n",
     "                          fit_p0=[0.5, t_q0, osc_freq, 0, 0.5],\n",
     "                          fit_bounds=([-0.5, 0, 0, -np.pi, -0.5],\n",
@@ -281,8 +277,6 @@
    "source": [
     "# Fitting T2 single echo\n",
     "\n",
-    "%matplotlib inline\n",
-    "\n",
     "t2echo_fit = T2Fitter(t2echo_backend_result, t2echo_xdata, qubits,\n",
     "                      fit_p0=[0.5, t_q0, 0.5],\n",
     "                      fit_bounds=([-0.5, 0, -0.5],\n",
@@ -317,8 +311,6 @@
    ],
    "source": [
     "# Fitting T2 CPMG\n",
-    "\n",
-    "%matplotlib inline\n",
     "\n",
     "t2cpmg_fit = T2Fitter([t2cpmg_backend_result1, t2cpmg_backend_result2],\n",
     "                      t2cpmg_xdata, qubits,\n",

--- a/tutorials/noise/9_entanglement_verification.ipynb
+++ b/tutorials/noise/9_entanglement_verification.ipynb
@@ -42,9 +42,7 @@
     "from qiskit import visualization\n",
     "\n",
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "%matplotlib inline"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {

--- a/tutorials/optimization/6_examples_max_cut_and_tsp.ipynb
+++ b/tutorials/optimization/6_examples_max_cut_and_tsp.ipynb
@@ -99,7 +99,7 @@
     "# useful additional packages \n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.axes as axes\n",
-    "%matplotlib inline\n",
+    "",
     "import numpy as np\n",
     "import networkx as nx\n",
     "\n",

--- a/tutorials/simulators/2_device_noise_simulation.ipynb
+++ b/tutorials/simulators/2_device_noise_simulation.ipynb
@@ -29,7 +29,7 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
+    "",
     "from qiskit import IBMQ, transpile\n",
     "from qiskit import QuantumCircuit\n",
     "from qiskit.providers.aer import AerSimulator\n",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes the  [bug](https://github.com/Qiskit/qiskit-tutorials/issues/1180) where all the circuit visualizations in the notebook are drawn twice.

### Details and comments
Removed  the code`%matplotlib inline` from the affected notebooks

