### PR TITLE
Removed %matplotlib inline, fixes issue #1201

### DIFF
--- a/tutorials/circuits/01_circuit_basics.ipynb
+++ b/tutorials/circuits/01_circuit_basics.ipynb
@@ -23,7 +23,6 @@
     "import numpy as np\n",
     "from qiskit import QuantumCircuit\n",
     "\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/tutorials/simulators/2_device_noise_simulation.ipynb
+++ b/tutorials/simulators/2_device_noise_simulation.ipynb
@@ -29,7 +29,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from qiskit import IBMQ, transpile\n",
     "from qiskit import QuantumCircuit\n",
     "from qiskit.providers.aer import AerSimulator\n",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
fixes the issue #1201


### Details and comments
%matplotlib inline was responsible for creating two images in a few tutorials, the issue contains all the necessary information.

