### PR TITLE
fixed typo in 3_summary_of_quantum_operations.ipynb

### DIFF
--- a/tutorials/circuits/3_summary_of_quantum_operations.ipynb
+++ b/tutorials/circuits/3_summary_of_quantum_operations.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "$$\\left|\\psi\\right\\rangle = \\cos(\\theta/2)\\left|0\\right\\rangle + \\sin(\\theta/2)e^{i\\phi}\\left|1\\right\\rangle$$\n",
     "\n",
-    "where $0\\leq \\phi < 2\\pi$, and $0\\leq \\theta \\leq \\pi$.  From this, it is clear that there is a one-to-one correspondence between qubit states ($\\mathbb{C}^2$) and the points on the surface of a unit sphere ($\\mathbb{R}^3$). This is called the Bloch sphere representation of a qubit state.\n",
+    "where $0\\leq \\phi < 2\\pi$, and $0\\leq \\theta \\leq \\pi$.  From this, it is clear that there is a one-to-one correspondence between qubit states ($\\mathbb{C}^2$) and the points on the surface of a unit sphere ($\\mathbb{S}^2$). This is called the Bloch sphere representation of a qubit state.\n",
     "\n",
     "Quantum gates/operations are usually represented as matrices. A gate which acts on a qubit is represented by a $2\\times 2$ unitary matrix $U$. The action of the quantum gate is found by multiplying the matrix representing the gate with the vector which represents the quantum state.\n",
     "\n",


### PR DESCRIPTION
Change the unit sphere notation to $\\mathbb{S}^2$

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Change the unit sphere notation to $\\mathbb{S}^2$

### Details and comments

In the original document it was written as $\\mathbb{R}^3$. The standard notation for unit sphere is $\\mathbb{S}^2$.
