### PR TITLE
fixed typo in 3_summary_of_quantum_operations.ipynb

### DIFF
--- a/tutorials/circuits/3_summary_of_quantum_operations.ipynb
+++ b/tutorials/circuits/3_summary_of_quantum_operations.ipynb
@@ -1446,7 +1446,7 @@
     "\n",
     "To work out these matrix elements, let\n",
     "\n",
-    "$$C_{(jk), (lm)} = \\left(\\underset{\\text{qubit}~1}{\\left\\langle j \\right|} \\otimes \\underset{\\text{qubit}~0}{\\left\\langle k \\right|}\\right) C_{U} \\left(\\underset{\\text{qubit}~1}{\\left| l \\right\\rangle} \\otimes \\underset{\\text{qubit}~0}{\\left| k \\right\\rangle}\\right),$$\n",
+    "$$C_{(jk), (lm)} = \\left(\\underset{\\text{qubit}~1}{\\left\\langle j \\right|} \\otimes \\underset{\\text{qubit}~0}{\\left\\langle k \\right|}\\right) C_{U} \\left(\\underset{\\text{qubit}~1}{\\left| l \\right\\rangle} \\otimes \\underset{\\text{qubit}~0}{\\left| m \\right\\rangle}\\right),$$\n",
     "\n",
     "compute the action of $C_{U}$ (given above), and compute the inner products.\n",
     "\n",


### PR DESCRIPTION
Fix typo

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix typo


### Details and comments
To compute C_{jk,lm}, the RHS state should be |m>

