### PR TITLE
Fix a broken json of getting stared page

### DIFF
--- a/tutorials/circuits/1_getting_started_with_qiskit.ipynb
+++ b/tutorials/circuits/1_getting_started_with_qiskit.ipynb
@@ -21,7 +21,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from qiskit import *\n",
+    "from qiskit import *\n"
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

#1206 breaks JSON of 1_getting_started_with_qiskit.ipynb
Due to this error. The tutorial looks corrupted.
https://qiskit.org/documentation/tutorials/circuits/1_getting_started_with_qiskit.html

This PR fixes it.




### Details and comments


