### PR TITLE
remove reference to Aqua in Measurement Error Mitigation

### DIFF
--- a/tutorials/noise/3_measurement_error_mitigation.ipynb
+++ b/tutorials/noise/3_measurement_error_mitigation.ipynb
@@ -1044,7 +1044,7 @@
     "## Running Qiskit Algorithms with Measurement Error Mitigation\n",
     "To use measurement error mitigation when running quantum circuits as part of a Qiskit algorithm, we need to include the respective measurement error fitting instance in the QuantumInstance. This object also holds the specifications for the chosen backend.\n",
     "\n",
-    "In the following, we illustrate measurement error mitigation of Aqua algorithms on the example of searching the ground state of a Hamiltonian with VQE."
+    "In the following, we illustrate measurement error mitigation on the example of searching the ground state of a Hamiltonian with VQE."
    ]
   },
   {


### PR DESCRIPTION
The tutorial https://qiskit.org/documentation/tutorials/noise/3_measurement_error_mitigation.html refers to Aqua in the text (not in the code). This PR removes that reference as Aqua is going to be removed from Qiskit soon.