### PR TITLE
CI is failing because cvxpy 1.1 is not compatible with scs 3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,8 @@ steps:
     source /tmp/docs_build/bin/activate
     pip install -c constraints.txt -U qiskit jupyter sphinx nbsphinx sphinx_rtd_theme networkx
     pip install -c constraints.txt 'matplotlib<3.3'
+    # cvxpy 1.1 is not compatible with the last version of scs. Once updated, the scs dependecy can be removed
+    pip install -c constraints.txt -U 'scs<3' scikit-learn
     pip install -c constraints.txt -U qiskit[visualization] cvxpy
     pip install -c constraints.txt pyscf
     sudo apt-get install -y pandoc graphviz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,10 +36,8 @@ steps:
     python -m pip install --upgrade pip setuptools wheel virtualenv
     virtualenv /tmp/docs_build
     source /tmp/docs_build/bin/activate
-    pip install -c constraints.txt -U qiskit jupyter sphinx nbsphinx sphinx_rtd_theme networkx
+    pip install -c constraints.txt -U qiskit jupyter sphinx nbsphinx sphinx_rtd_theme networkx scikit-learn
     pip install -c constraints.txt 'matplotlib<3.3'
-    # cvxpy 1.1 is not compatible with the last version of scs. Once updated, the scs dependecy can be removed
-    pip install -c constraints.txt -U 'scs<3' scikit-learn
     pip install -c constraints.txt -U qiskit[visualization] cvxpy
     pip install -c constraints.txt pyscf
     sudo apt-get install -y pandoc graphviz

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,2 @@
 docplex==2.15.194
-cvxpy<1.1.8
 decorator==4.4.2


### PR DESCRIPTION
I think the failing in CI is because scs 3 is braking backwards compatibility and cvxpy 1.1 cannot handle it. For some reason, that also requires `scikit-learn`. 