### PR TITLE
Small render error in 02_operators_overview

### DIFF
--- a/tutorials/circuits_advanced/02_operators_overview.ipynb
+++ b/tutorials/circuits_advanced/02_operators_overview.ipynb
@@ -81,7 +81,7 @@
     "The operator object stores the underlying matrix, and the input and output dimension of subsystems. \n",
     "\n",
     "* `data`: To access the underlying Numpy array, we may use the `Operator.data` property.\n",
-    "* `dims`: To return the total input and output dimension of the operator, we may use the `Operator.dim` property. *Note: the output is returned as a tuple `(input_dim, output_dim)`, which is the reverse of the shape of the underlying matrix.*"
+    "* `dims`: To return the total input and output dimension of the operator, we may use the `Operator.dim` property. *Note: the output is returned as a tuple* `(input_dim, output_dim)`, *which is the reverse of the shape of the underlying matrix.*"
    ]
   },
   {
@@ -307,7 +307,7 @@
     "\n",
     "* `Pauli` objects\n",
     "* `Gate` and `Instruction` objects\n",
-    "* `QuantumCircuits` objects\n",
+    "* `QuantumCircuit` objects\n",
     "\n",
     "Note that the last point means we can use the `Operator` class as a unitary simulator to compute the final unitary matrix for a quantum circuit, without having to call a simulator backend. If the circuit contains any unsupported operations, an exception will be raised. Unsupported operations are: measure, reset, conditional operations, or a gate that does not have a matrix definition or decomposition in terms of gate with matrix definitions."
    ]
@@ -578,7 +578,7 @@
     "\n",
     "### Tensor Product\n",
     "\n",
-    "Two operators $A$ and $B$ may be combined into a tensor product operator $A\\otimes B$ using the `Operator.tensor` function. Note that if both A and B are single-qubit operators, then `A.tensor(B)` = $A\\otimes B$ will have the subsystems indexed as matrix B  on subsystem 0, and matrix $A$ on subsystem 1."
+    "Two operators $A$ and $B$ may be combined into a tensor product operator $A\\otimes B$ using the `Operator.tensor` function. Note that if both $A$ and $B$ are single-qubit operators, then `A.tensor(B)` = $A\\otimes B$ will have the subsystems indexed as matrix $B$  on subsystem 0, and matrix $A$ on subsystem 1."
    ]
   },
   {
@@ -618,7 +618,7 @@
    "source": [
     "### Tensor Expansion\n",
     "\n",
-    "A closely related operation is `Operator.expand`, which acts like a tensor product but in the reverse order. Hence, for two operators $A$ and $B$ we have `A.expand(B)` = $B\\otimes A$ where the subsystems indexed as matrix A  on subsystem 0, and matrix $B$ on subsystem 1."
+    "A closely related operation is `Operator.expand`, which acts like a tensor product but in the reverse order. Hence, for two operators $A$ and $B$ we have `A.expand(B)` = $B\\otimes A$ where the subsystems indexed as matrix $A$ on subsystem 0, and matrix $B$ on subsystem 1."
    ]
   },
   {
@@ -734,7 +734,7 @@
     "\n",
     "Note that the previous compose requires that the total output dimension of the first operator $A$ is equal to total input dimension of the composed operator $B$ (and similarly, the output dimension of $B$ must be equal to the input dimension of $A$ when composing with `front=True`).\n",
     "\n",
-    "We can also compose a smaller operator with a selection of subsystems on a larger operator using the `qargs` kwarg of `compose`, either with or without `front=True`. In this case, the relevant input and output dimensions of the subsystems being composed must match. *Note that the smaller operator must always be the argument of `compose` method.*\n",
+    "We can also compose a smaller operator with a selection of subsystems on a larger operator using the `qargs` kwarg of `compose`, either with or without `front=True`. In this case, the relevant input and output dimensions of the subsystems being composed must match. *Note that the smaller operator must always be the argument of* `compose` *method.*\n",
     "\n",
     "For example, to compose a two-qubit gate with a three-qubit Operator:"
    ]


### PR DESCRIPTION
### Summary

In a couple of places, Sphinx doesn't render a couple of code blocks correctly because they are inside an italicized string.

### Details and comments

* Placing a block of code inside text in italics causes Sphinx to render the block of text incorrectly, as seen in the images below (Figure 1 and Figure 2).
The way to fix this is to break the text into italics so that it doesn't include the block of text.
This is presented in the [Operator Properties](https://qiskit.org/documentation/tutorials/circuits_advanced/02_operators_overview.html#Operator-Properties) and [Subsystem Composition](https://qiskit.org/documentation/tutorials/circuits_advanced/02_operators_overview.html#Subsystem-Composition) sections.

* These are not errors, just a minor formatting consistency issue. When mentioning the arrays `A` and `B`, they are sometimes not displayed in latex format, for consistency I have added those names between the $$ symbols, which will cause consistent rendering by Sphinx.
In the [Tensor Product](https://qiskit.org/documentation/tutorials/circuits_advanced/02_operators_overview.html#Tensor-Product) and [Tensor Expansion](https://qiskit.org/documentation/tutorials/circuits_advanced/02_operators_overview.html#Tensor-Expansion) sections (Figures 3 and 4)

* This is a small naming error for the `QuantumCircuit` class, which has an extra 's' in the [Converting classes to Operators](https://qiskit.org/documentation/tutorials/circuits_advanced/02_operators_overview.html#Converting-classes-to-Operators) section (Figure 5)

-------
Figure 1
![image](https://user-images.githubusercontent.com/1554515/156952537-360718f9-77bb-40c8-a354-250085cb98cb.png)

Figure 2
![image](https://user-images.githubusercontent.com/1554515/156952545-99eca5e9-3ffc-4f93-8817-1b639ec3df82.png)

Figure 3
![image](https://user-images.githubusercontent.com/1554515/156952744-0bed953d-ef53-4498-a69f-541f1052eb07.png)

Figure 4
![image](https://user-images.githubusercontent.com/1554515/156952760-2b60c54b-7b03-4680-929b-38655b077a26.png)

Figure 5
![image](https://user-images.githubusercontent.com/1554515/156952875-0e04c24d-1894-4e54-b939-49fe6236dafa.png)

