### PR TITLE
Update 04_transpiler_passes_and_passmanager.ipynb

### DIFF
--- a/tutorials/circuits_advanced/04_transpiler_passes_and_passmanager.ipynb
+++ b/tutorials/circuits_advanced/04_transpiler_passes_and_passmanager.ipynb
@@ -786,7 +786,7 @@
     "print(\"node op: \", node.op)\n",
     "print(\"node qargs: \", node.qargs)\n",
     "print(\"node cargs: \", node.cargs)\n",
-    "print(\"node condition: \", node.condition)"
+    "print(\"node condition: \", node.op.condition)"
    ]
   },
   {


### PR DESCRIPTION
DeprecationWarning: The DAGNode 'condition' attribute is deprecated as of 0.18.0 and will be removed no earlier than 3 months after the release date. You can use 'DAGNode.op.condition' if the DAGNode is of type 'op'.
  print("node condition: ", node.condition)

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


