### PR TITLE
Fix deprecated reference to node.condition

### DIFF
--- a/tutorials/circuits_advanced/04_transpiler_passes_and_passmanager.ipynb
+++ b/tutorials/circuits_advanced/04_transpiler_passes_and_passmanager.ipynb
@@ -736,10 +736,10 @@
     {
      "data": {
       "text/plain": [
-       "[<qiskit.dagcircuit.dagnode.DAGNode at 0x7f1eebb870b0>,\n",
-       " <qiskit.dagcircuit.dagnode.DAGNode at 0x7f1eebb87820>,\n",
-       " <qiskit.dagcircuit.dagnode.DAGNode at 0x7f1eebb87eb0>,\n",
-       " <qiskit.dagcircuit.dagnode.DAGNode at 0x7f1eebb876d0>]"
+       "[<qiskit.dagcircuit.dagnode.DAGOpNode at 0x7f1eebb870b0>,\n",
+       " <qiskit.dagcircuit.dagnode.DAGOpNode at 0x7f1eebb87820>,\n",
+       " <qiskit.dagcircuit.dagnode.DAGOpNode at 0x7f1eebb87eb0>,\n",
+       " <qiskit.dagcircuit.dagnode.DAGOpNode at 0x7f1eebb876d0>]"
       ]
      },
      "execution_count": 18,
@@ -755,7 +755,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each node is an instance of the ``DAGNode`` class. Let's examine the information stored in the second op node."
+    "Each node is an instance of the ``DAGOpNode`` class. Let's examine the information stored in the second op node."
    ]
   },
   {
@@ -786,7 +786,7 @@
     "print(\"node op: \", node.op)\n",
     "print(\"node qargs: \", node.qargs)\n",
     "print(\"node cargs: \", node.cargs)\n",
-    "print(\"node condition: \", node.condition)"
+    "print(\"node condition: \", node.op.condition)"
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1302

### Details and comments

This PR fixes a deprecated reference in https://github.com/Qiskit/qiskit-tutorials/blob/721d67ac97e8f0ca3b9b4156cc35a9a777363d12/tutorials/circuits_advanced/04_transpiler_passes_and_passmanager.ipynb to `node.condition` with `node.op.condition`. In addition references to `DAGNode` have been changed to `DAGOpNode`.
