### PR TITLE
Minor improvements to opflow tutorial

### DIFF
--- a/tutorials/operators/01_operator_flow.ipynb
+++ b/tutorials/operators/01_operator_flow.ipynb
@@ -489,7 +489,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`StateFn`s carry a coefficient. This allows us multiply states by a scalar, and so to construct sums."
+    "`StateFn`s carry a coefficient. This allows us to multiply states by a scalar, and so to construct sums."
    ]
   },
   {
@@ -1411,12 +1411,13 @@
     "These composite `OperatorBase`s are how we construct increasingly complex and rich computation out of `PrimitiveOp` and `StateFn` building blocks.\n",
     "\n",
     "Every `ListOp` has four properties:\n",
+    "\n",
     "* `oplist` - The list of `OperatorBase`s which may represent terms, factors, etc.\n",
     "* `combo_fn` - The function taking a list of complex numbers to an output value which defines how to combine the outputs of the `oplist` items. For broadcasting simplicity, this function is defined over NumPy arrays.\n",
     "* `coeff` - A coefficient multiplying the primitive. Note that `coeff` can be int, float, complex or a free `Parameter` object (from `qiskit.circuit` in Terra) to be bound later using `my_op.bind_parameters`.\n",
     "* `abelian` - Indicates whether the Operators in `oplist` are known to mutually commute (usually set after being converted by the `AbelianGrouper` converter).\n",
     "\n",
-    "Note that `ListOp` supports typical iteration overloads, so you can use indexing like `my_op[4]` to access the `OperatorBase`s in `oplist`."
+    "Note that `ListOp` supports typical sequence overloads, so you can use indexing like `my_op[4]` to access the `OperatorBase`s in `oplist`."
    ]
   },
   {
@@ -2060,7 +2061,7 @@
    "source": [
     "### Executing `CircuitStateFn`s with the `CircuitSampler`\n",
     "\n",
-    "The `CircuitSampler` traverses an Operator and converts any `CircuitStateFns` into approximations of the resulting state function by a `DictStateFn` or `VectorStateFn` using a quantum backend. Note that in order to approximate the value of the `CircuitStateFn`, it must 1) send the state function through a depolarizing channel, which will destroy all phase information and 2) replace the sampled frequencies with **square roots** of the frequency, rather than the raw probability of sampling (which would be the equivalent of sampling the **square** of the state function, per the Born rule.)"
+    "The `CircuitSampler` traverses an Operator and converts any `CircuitStateFn`s into approximations of the resulting state function by a `DictStateFn` or `VectorStateFn` using a quantum backend. Note that in order to approximate the value of the `CircuitStateFn`, it must 1) send the state function through a depolarizing channel, which will destroy all phase information and 2) replace the sampled frequencies with **square roots** of the frequency, rather than the raw probability of sampling (which would be the equivalent of sampling the **square** of the state function, per the Born rule)."
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I noticed a few very minor issues with the text when carefully reading the opflow tutorial, which I have corrected in this PR.

### Details and comments

- The added newline is necessary for the list to display correctly at https://qiskit.org/documentation/tutorials/operators/01_operator_flow.html#ListOps:-SummedOp,-ComposedOp,-TensoredOp
- I consider the word "sequence" to be more precise than "iteration" here, as an iterable need not implement `__getitem__`.  The changed language is consistent with [the built-in types](https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range) and [the language used for Python's abstract base classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes).