### PR TITLE
Fixed typo of C_{U}

### DIFF
--- a/tutorials/circuits/3_summary_of_quantum_operations.ipynb
+++ b/tutorials/circuits/3_summary_of_quantum_operations.ipynb
@@ -1445,7 +1445,7 @@
     "\n",
     "To work out these matrix elements, let\n",
     "\n",
-    "$$C_{(jk), (lm)} = \\left(\\underset{\\text{qubit}~1}{\\left\\langle j \\right|} \\otimes \\underset{\\text{qubit}~0}{\\left\\langle k \\right|}\\right) C_{U} \\left(\\underset{\\text{qubit}~1}{\\left| l \\right\\rangle} \\otimes \\underset{\\text{qubit}~0}{\\left| k \\right\\rangle}\\right),$$\n",
+    "$$C_{(jk), (lm)} = \\left(\\underset{\\text{qubit}~1}{\\left\\langle j \\right|} \\otimes \\underset{\\text{qubit}~0}{\\left\\langle k \\right|}\\right) C_{U} \\left(\\underset{\\text{qubit}~1}{\\left| l \\right\\rangle} \\otimes \\underset{\\text{qubit}~0}{\\left| m \\right\\rangle}\\right),$$\n",
     "\n",
     "compute the action of $C_{U}$ (given above), and compute the inner products.\n",
     "\n",

--- a/tutorials/circuits/3_summary_of_quantum_operations.ipynb
+++ b/tutorials/circuits/3_summary_of_quantum_operations.ipynb
@@ -1688,7 +1688,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Controlled $Z$ (or, controlled Phase) gate\n",
+    "#### Controlled $Z$ (or, controlled Phase-Flip) gate\n",
     "\n",
     "Similarly, the controlled Z gate flips the phase of the target qubit if the control qubit is $\\left|1\\right\\rangle$. The matrix looks the same regardless of whether the MSB or LSB is the control qubit:\n",
     "\n",


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixed typo of C_{U}:

### Details and comments
Fixed typo of C_{U}:
"$$C_{(jk), (lm)} = \\left(\\underset{\\text{qubit}~1}{\\left\\langle j \\right|} \\otimes \\underset{\\text{qubit}~0}{\\left\\langle k \\right|}\\right) C_{U} \\left(\\underset{\\text{qubit}~1}{\\left| l \\right\\rangle} \\otimes \\underset{\\text{qubit}~0}{\\left| k \\right\\rangle}\\right),$$\n"

It should be 

"$$C_{(jk), (lm)} = \\left(\\underset{\\text{qubit}~1}{\\left\\langle j \\right|} \\otimes \\underset{\\text{qubit}~0}{\\left\\langle k \\right|}\\right) C_{U} \\left(\\underset{\\text{qubit}~1}{\\left| l \\right\\rangle} \\otimes \\underset{\\text{qubit}~0}{\\left| m \\right\\rangle}\\right),$$\n"
