### PR TITLE
Update operator tutorial to avoid deprecated Pauli construction

### DIFF
--- a/tutorials/circuits_advanced/02_operators_overview.ipynb
+++ b/tutorials/circuits_advanced/02_operators_overview.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.554914Z",
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.572857Z",
@@ -62,7 +62,7 @@
        "         input_dims=(2, 2), output_dims=(2, 2))"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.589962Z",
@@ -103,7 +103,7 @@
        "       [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]])"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.615497Z",
@@ -128,7 +128,7 @@
        "(4, 4)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -151,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:56.804167Z",
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:57.764881Z",
@@ -215,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:58.292849Z",
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:02:58.779572Z",
@@ -275,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:03:02.187313Z",
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:03:02.854419Z",
@@ -332,7 +332,7 @@
        "         input_dims=(2, 2), output_dims=(2, 2))"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -340,13 +340,13 @@
    "source": [
     "# Create an Operator from a Pauli object\n",
     "\n",
-    "pauliXX = Pauli(label='XX')\n",
+    "pauliXX = Pauli('XX')\n",
     "Operator(pauliXX)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:03:03.064145Z",
@@ -364,7 +364,7 @@
        "         input_dims=(2, 2), output_dims=(2, 2))"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:03:03.353613Z",
@@ -392,7 +392,7 @@
        "         input_dims=(2,), output_dims=(2,))"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -404,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:03:47.550069Z",
@@ -431,7 +431,7 @@
        "         input_dims=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2), output_dims=(2, 2, 2, 2, 2, 2, 2, 2, 2, 2))"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -460,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:03:49.196556Z",
@@ -473,19 +473,19 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUoAAACoCAYAAACG0qc4AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAVdUlEQVR4nO3de1hUdcIH8O8MILfhjshNRARRJkAETFpdRMRLaZnircC7GPH6eMlC17Z631rAS7Xl81Zgmpi57QtqWOmWlLJu5CZeMJQV8YoImogKKAoz8/6hkiPCb9QZDgPfz/PM88BvzjnzHYSvv3PmzBmZRqPRgIiIWiSXOgARUXvHoiQiEmBREhEJsCiJiARYlEREAixKIiIBFiURkQCLkohIgEVJRCTAoiQiEmBREhEJsCiJiARYlEREAixKIiIBFiURkQCLkohIgEVJRCTAoiQiEmBREhEJsCiJiARYlEREAixKIiIBFiURkQCLkohIgEVJRCTAoiQiEjCVOgC1jWM/AjUXpU5hHGxcAP+hUqeg9oRF2UnUXASunJM6Recgk8kkeVyNRiPJ43YG3PUmIhJgURIRCbAoiYgEWJRERAIsSiIiARYlEZEAi5JIYjKZDP7+/oiOjsawYcMQHBwMMzOzFpe3tLTEwoULIZfzz7et8DxKIgnIZDIMHz4ciYmJGDp0KGxsbLTuv3nzJvbu3YuMjAxkZ2fj1q1bAG6XZE5ODmJiYuDh4YHFixdLEb/TkWl4lmqnUPAlTzjXlb0nEDb50dcXnXAeEBCA9evXIzw8vGmsrKwMx48fh1qthpeXF3r37t1035kzZzBr1izk5+c3lWRlZSWGDh2K4uLipuX4p2w4nLvfQ61WY9WqVfDz84OFhQWCg4ORl5cHf39/JCQkSB3PYFRqFTK+eRWxb3XFs6/b4L8zx+Nq3SWpY3VI8fHxOHDgAMLDw1FeXo6lS5fCw8MDXl5eiI6ORkxMDPz9/WFvb485c+agqKgIPXr0QG5uLo4cOdJiSZJhsSjvMXPmTLz99tuYO3cuduzYgYkTJ2LKlCk4efIkQkNDpY5nMF/uSkP+kRysnvdv/G3Z7Wnn8r/FS5yq44mLi8OGDRtgbm6ONWvWoG/fvkhLS8P58+ebLXv16lV8+umnCAkJwZtvvgm1Wo2ePXuirq6OJSkBFuUdmzZtQmZmJrZt24bFixcjKioKy5YtQ0REBBobG5uK8sKFCxg+fDisrKwQHByMgwcPSpz88W3fm4FJUclwc/KBtaUd5jyzAvuO/QOVl09LHa3D6NOnD9asWQMAeO2115CQkICamhrhemZmZhg0aBDkcjk0Gg2sra3h5+dn6Lh0HxblHampqRg5ciQiIyO1xn19fWFmZobAwEAAQGJiIvr06YOqqiokJSUhNjYWKpVKish6UXfjKi5eOQs/j99nzO7OvWBlYYuTFYclTNaxfPbZZ7CwsMDatWuxcuVKnda594WbyspKpKamAgDS09NhZ2dnyLh0HxYlgHPnzqGoqAgTJkxodt/Zs2ehVCphbm6OmpoafPvtt3jjjTdgaWmJhIQEqFQq7N27V29ZZDKZQW55ebsf+Hh1N68BAKwttf/wFBb2uF5/TW/Py5jk5e1+rJ/1/aKiojBw4EBUVlZi0aJFOmW4vySHDh2K119/Hfn5+XB1dcX06dObrWOo352OfNMVixK3ixIAXF1dtcZv3LiBvLy8pt3u48ePw8nJCc7Ozk3LBAYG4ujRo20XVs+szG+fllJ346rWeG39FVhZ2EoRqcNJTEwEAHz00Ue4dk38n8+DSrK4uBgajQYrVqzQ2ia1DRYl0FR8JSUlWuMrVqxARUUF+vfvDwCoq6uDra12edja2qK2tlZvWTQajUFukZFDHvh4Ckt7uNh7obT8QNNYRdVJXK+/Bh+3IL09L2MSGTnksX7W94uOjgYAbNiwQfjYLZXkXd988w2qq6vh7+8PDw8PrXUN9bvTkW+64gnnAHx8fBAUFISUlBQ4OjrCw8MD2dnZ2L59OwA0zSitra2bHYC/du0aFApFm2fWp6cHJuDvu5cj2DcKtlZOWLM9GWG9R8DV0VvqaEbP29sbjo6OuHDhAs6cOdPqsqKSBACVSoWCggLExMQgNDQU5eXlhoxPd3BGCUAulyMrKwtKpRKJiYmYMWMGnJ2dkZSUBFNTUwQF3Z5Z+fn54dKlS6iqqmpat6ioCAEBAVJF14vJUUswsO8Y/NcH4ZjyjgfUahWWvLBR6lgdgru7OwDgxIkTrS6nS0neVVpaqrVtMjy+M6cV8fHxKCwsxOHDv7/6O27cOHh5eSEtLQ0bN25ESkoKjh8/DhMTEwmTivGdObrT5ztzZDIZrK2tYWJigqtXr7a4joODA3788Ue4uroKz5NUKBSQy+Woq6vTOuOCf8qGw13vVhQUFGDgwIFaYx9//DHi4uLg4OAAPz8/bN68ud2XJElHo9HodAy7uroa0dHRcHZ2bnas/H76PCZOumFRtqC2thYlJSV4+eWXtca7deuGnTt3SpSKOrLLly/j8uXLUsegB2BRtkChUBj1ieREpD98MYeISIBFSUQkwKIkIhJgURIRCbAoiYgEWJRERAI8PYhIzx7lHTJLlmcAANKSE7S+pvaBM0oiIgEWJRGRAIuS2sSYZQocPf2z1DGIHgmLkoTiUryRu7/5ZddaGn+Qr/9SiwDvCABA4YndGJHMw+NkPFiUZJQaVQ1SR6BOhEVJj+27fesxLc0XW//1Iaa844nn33DAX7PnQqX+/aIiMa/KUHTqX7h09Tz+9OkoqNUqjFmmwJhlCnxfkAkAWPn3GXjhne549nUbzFoZgB8Pbmpa/+4sdOf+zxGf6oNxbzri6/yPMfe9YK0s5y+dwIhkU1yobv1q4kQPg/s/pBcXqs+guuYCMpecwG9XyjDvwwEI9Pkjovu/qLWcs507UmbvwGsZw/D1X7Svq/hEz0GYO3oVrC3t8c/DWVjx5VT0cu+HHt1uX0FerVZh33924JMFB2FiYgaVuhEZ376KY2X74N89HACwY99a9Pcdhm4OPdrmiVOnwBkl6YW5mSWmjfgfdDE1h4ezL/r5RaPkXMFDbWPUgFmwtXaCidwEUf0mo6dbEApP7NZaZvbTabC2tINFFytYW9hiSL/J2PHLWgCASq3CzoJMPP3kHH09LSIAnFGSDkxMzNCobn5MsFHVANM7Mzt7hQtM5L9f6d3CzBrXb9Y0W6clarUaG3a+hbzCv+NyTSVkkKH+Vh2u1v7WtIxcJkdX++5a640eOBevZQzDS2Pew8HSH6BSNyJC+ewjPEuilrEoScjVwRvnL5Vqjd24WYvq2gtwc/LB6cojD7U9maz5jsyuQ3/Djl8+Rdqc79HDJQByuRwvfxAGDTT3rtjsQ+v9u4fD3akX/nk4Cz8VbcXwsOkwNTF7qDxEItz1JqHhYdOx/d8Z+PXkHqjUKtRcr8ZHOfPh3U0JX/eQh96eo40r1GoVKi6fahq7Xn8NJnJT2Ft3hUajxj9+WYeT5wt12t7TTyYgO+9d/PKf7Rg1YPZD5yES4YyShKL7v4ibDdexemsSLlw5A8suCgT5ROLtmd/AxOThf4U8u/bGmIiXMe/DAWhUNSBp7GrEhE3DwRM/YtpyX5ibWWFY/3gE9hysW76QF7Hm21eh9P4DPLv6PXQeIhF+XG0n0ZE/rlaj0WBqqg9mjPoLhoa88Njbe9yPq30UvChG+8ZdbzJ6Pxz4Ag2qWxgcGCt1FOqguOtNRi32ra4wkZti0YS1MDPtInUc6qBYlGTUst/6TbwQ6eT+MwragrEc+eOuNxGRAIuSiEiARUlEJMCiJCISYFESEQmwKImIBFiURNQmbGxsIJcbZ+XwPEoieihdu3bF+PHjER4eDqVSCSsrK9TX16O4uBgFBQXYsmULysvLtdaxt7dHbm4uDh8+jNmzZ0OtVkuU/tGwKIlIJ56enkhJScHEiRNhbm7e7P7w8HBMnToV7733HnJycrB06VIcP368qSRDQ0NhZ2cHR0dHXLp0SYJn8OiMcx5sIGq1GqtWrYKfnx8sLCwQHByMvLw8+Pv7IyGBFyigzmvq1KkoKipCfHw8zMzM8PXXX2PevHkYPHgwgoKC8NRTTyExMRFZWVnQaDQYP348CgsLkZyc3FSSpaWlGDJkiNGVJMAZpZaZM2di69at+POf/4zQ0FDk5+djypQp+O2337Bo0SKp4xnErkNfYlv+/+Lk+ULUN1zHd8sbpY5E7cySJUuQmpoKAPjqq6+wcOFCnD59utlyP//8Mz755BO4ubkhNTUV06ZNQ1paGgA0leT9u+TGgjPKOzZt2oTMzExs27YNixcvRlRUFJYtW4aIiAg0NjYiNDQUAPDmm28iIOD2Fbizs7MlTv34FJYOGBPxMhKf/avUUagdiouLQ2pqKlQqFebOnYvnn3/+gSV5r4qKCixYsAAnT55sGvviiy+MtiQBFmWT1NRUjBw5EpGRkVrjvr6+MDMzQ2BgIADAz88PH3zwAQYMGCBFTL0L9x+BoSFT4ObkI3UUamfc3d2xevVqAEBSUhIyMjJ0Wu/uMUkfHx9UVFQAAJKTk9GnTx+DZTU0FiWAc+fOoaioCBMmTGh239mzZ6FUKpsOXsfFxSEmJgYWFhYGySK787kw+r7l5e02SN6OKC9vt8H+HVq63XX/11JkuOudd96Bvb09tm3bhvT0dJ1+dve+cFNaWorw8HCsXbsWFhYWWLVqVbPl2/o5ip5zS1iUuF2UAODq6qo1fuPGDeTl5TXtdhN1Fo6OjpgyZQrUajUWLlyo0zr3l+TdY5LJycmor6/HqFGj0LNnTwMnNwwWJQBnZ2cAQElJidb4ihUrUFFRgf79+7dZFo1GY5BbZOSQNnsOxi4ycojB/h1aut11/9dSZACAsWPHwsLCAt9//73WscaWtFSSAFBVVYXs7GzI5XJMnDhRa722fo6tPefW8FVvAD4+PggKCkJKSgocHR3h4eGB7OxsbN++HQA4o6ROJywsDACQm5srXLa1krxr586diIuLa9quseGMEoBcLkdWVhaUSiUSExMxY8YMODs7IykpCaampggKCpI6osGo1CrcaqhHQ+MtAMCthnrcaqg3mitPk2EolUoAQGFh6x8ZrEtJAsChQ4e0tmtsOKO8o3fv3ti1a5fWWHx8PPr27QtLS8umsYaGBqhUKqjVajQ0NKC+vh7m5uaSXEZfH3L3f45V/zej6ftn/nT7uX6+9BRcHb0lSkVSy8zMxJ49e3Ds2LFWl3v//feFJQkAZWVlSElJQWVlpSHiGhyLshUFBQUYOHCg1ticOXOQmZkJANizZw8A4NSpU/D29m7reHoxInw6RoRPlzoGtTPr1q3TablXXnkFNjY2mD9/fqvnSVZXV2PZsmX6itfmuOvdgtraWpSUlDR7IWf9+vXNDggba0kSPa7Lly8jNjbWqE8m1wVnlC1QKBRQqVRSxyCidoAzSiIiARYlEZEAi5KISIBFSUQkwKIkIhJgURIRCbAoiYgEeB5lJ2HjInUC49FZf1YP+/7+JctvX8g3LTlB6+uOiEXZSfgPlToBkfHirjcRkQCLkohIgEVJRCTAoiQiEmBREhEJsCiJiARYlEREAixKIiIBFiURkQCLkohIgEVJRCTAoiQiEmBREhEJsCiJiARYlEREAixK0klZWRmio6PRt29fPPHEE1i6dKnUkeiO3bt3Q6lUwtfXF7Nnz4ZKpZI6ktC8efPg6ekJU1PjuCQui5J0YmpqiuXLl6O4uBgHDhxAfn4+cnJypI7V6anVasyePRtZWVkoLS3FtWvXsHHjRqljCU2aNAn79++XOobOWJSkEzc3N4SFhQEAunTpgqCgIJw9e1biVLRv3z64u7sjICAAADBr1ixs3rxZ4lRigwYNQrdu3aSOoTPjmPdSu1JVVYWvvvoKO3fulDqK0dr180Ec/s/JZuMffLa52dduLk6Y+MyQB27n3Llz6N69e9P3Xl5eKCsr02/YO6qv1uDzrd/j/o/WeVBmAJj4zBC4uTgZJEtb44ySHsrNmzcRGxuLBQsWoE+fPlLHMVohSj9cunwFFRerUHGxqmn8/q8rLlYh9IneLW5Ho9FAJpNpfW8oDnY2cOvqpFNmOxvrDlOSAIuSHoJKpcKLL76IkJAQvPLKK1LHMWr2tgpEPtlPuJyytzd69XBv8f7u3btrHQIpKyuDp6enXjI+yIjIAehi1vqOqFwuwzNRAw2WQQosStJZQkICbGxs8O6770odpUP445PBsLOxbvF+ExM5nh7SeuGEhYWhvLwcR48eBQCsXbsW48aN02vOe9kqrBAVEdLqMhH9lejqZG+wDFJgUZJOfvrpJ6xbtw4FBQUICQlBv3798OGHHwIw7O5eR9bFzBQjIwe0eP+gsEA4Odi2ug0TExOsWbMGsbGx6NWrFxQKBeLj4/UdtVkue1vFA++zsjBH9B9ChduYO3cuPD09oVKp4OnpiaSkJH3H1CuZhr/l9JiKSk4hf38RpoyJho3CSuo4RkWt0eDjz3NQVnFRa1xhZYnFCZNgYd5FomStO1x8Apu2/dBs/LmYPyCiv1KCRIbFGeVDyMnJwejRo+Hi4gJzc3P06NEDL7zwAn799Vepo0lGrdHgh58O4FrtdVhZWUgdx+jIZTKMiY5oNj58cFi7LUkACOzjA29PV60xFycHDOjXV6JEhsWi1EFjYyMmT56MsWPHorCwEOPGjcP8+fMREhKCzZs3o7y8XOqIkjl6/DQqLlYh+qn+MJHz1+lReHl0Q78A36bvXbs6IizIX8JEYjKZDKOjIyC7Z2x0dESH/R3grrcOXnrpJaSnp2POnDl4//33YW39+wH4srIy2Nvbw8bGRi+PtWR5hl62Q0RiackJOi3HE84F9uzZg/T0dIwcORLp6ela56wB0DrZl4g6Js4oBcaPH48tW7bg0KFDCA4OljpOu6HWaLB6/RY0NDZi4awJHXaXqy3damhE7fUbcLTTz95JW7lwqRrdnB2kjmFQLEoBW1tbODk54dSpU23yeNz1Jmo7uu56cxrQiitXrqCmpgbe3t5SRyEiCXFG2Yrq6mo4OjoiICAAR44ckTpOu1FUcgobt+7EpNFRCFH6SR2HyOA4o2yFg4MDevXqheLiYuTm5ja7/9ixYxKkktbd8yadHe0Q1LeX1HGI2gRf9RZISUnBpEmTMHLkSDz33HPw9fXFxYsXkZ+fj4CAAGzdulXqiG2q7voNmMjl+CPPm6ROhLveOvjuu++wcuVK7Nu3D/X19XBxccGAAQOwYMECDB48WOp4bU6j0UCD2+8qIeoMWJRERALcdyIiEmBREhEJsCiJiARYlEREAixKIiIBFiURkQCLkohIgEVJRCTAoiQiEmBREhEJsCiJiARYlEREAixKIiIBFiURkQCLkohIgEVJRCTAoiQiEmBREhEJsCiJiARYlEREAixKIiIBFiURkQCLkohIgEVJRCTAoiQiEmBREhEJsCiJiAT+H1O+SjobxtSqAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQUAAACoCAYAAADpY/sVAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAU+ElEQVR4nO3de1RU170H8O/MMIC8VVREUORZGQXkYYi1DkSjBDXXJqhgS5WA+MAubW2qqTXRmFCfvZj2RmMx0Rvv1VwJ5iXGmIQZNUQFFZQYSxUVMdSgEQFRgZm5fxgm2QIOGIYzo9/PWmetYc95/M5Bvu595sw5MoPBYAAR0ffkUhdARJaFoUBEAoYCEQkYCkQkYCgQkYChQEQChgIRCRgKRCRgKBCRgKFARAKGAhEJGApEJGAoEJGAoUBEAoYCEQkYCkQkYCgQkYChQEQChgIRCRgKRCRgKBCRgKFARAKGAhEJGApEJGAoEJGAoUBEAhupC7B2//wcqPtW6iq6j3NfIOgJ86x74cKFKC4uNs/KTQgLC0NWVpYk27Y0DIWfqO5boKZS6ioeDsXFxdBqtVKX8cjj8IGIBAwFIhIwFIhIwFAgIgFDgYgEDAUiEvAjSbJqdnZ2UKlU6N27N3Q6HS5evIhz5861O7+fnx+ioqKwc+fObqzSujAUyOo4ODggKSkJaWlpiIiIgFKpFN6vqanBvn378Prrr+PAgQPGdj8/P2g0Gnh6eqKurg579uzp7tKtAkOBrMrkyZOxadMm9OvXDwCg1+tx+vRpXL58GUqlEkFBQejfvz+mTZuGadOmIT8/H8899xwUCgU0Gg28vLxw4MABaDQaaXfEgln0OQW9Xo9169YhICAA9vb2CA0NhVarRVBQENLT06Uu7750eh02f/Q8Epb3wdN/dsaKbc/ixs2rUpdlteRyOTZu3Ijdu3ejX79+KCwsRHJyMlxcXKBSqTBu3DjExsbC09MTPj4+WLFiBaqrqxEbG4vS0lIcPnzYGAjx8fG4efOm1LtksSw6FFJTU7Fy5UrMnj0be/fuxdSpU5GUlITy8nJERERIXd597cxfhYKv3sfffnsEO5bevQ569Y5kiauyXtnZ2ZgzZw5u3bqF+fPn47HHHsP27dvb/OO+ePEili9fjiFDhiAvLw+Ojo5wd3dHaWkpA6EDLHb4sGPHDmzduhUajQZqtRoAEBsbi+PHjyM3Nxfh4eESV3h/eYc349dPvoj+vX0BALMmrMGM1f64cv0i+vUcJHF11iUtLQ0pKSm4efMm4uLicOjQoQ4t5+bmhpCQEOPPXl5ecHV1ZSiYYLE9hczMTMTFxRkDoYW/vz+USqXxl33hwgWo1WoEBgZi2LBhOHjwoBTlCupv1eDbmgoEDPihN+Pp7gcHexec+6ZEwsqsj6enJ9avXw/gbjh0NBBaTiq2DBn27NkDNzc3bNq0yZzlPhQsMhQqKytRWlqKKVOmtHqvoqICKpUKdnZ2AIDZs2dj2rRpKCsrwxtvvIHExEQ0Njaa3IZMJuuSSavVtFp3w506AIBjD1eh3cneDQ23ax/giFgOrVbTZceu9bFs/Q3JjIwMuLi44IMPPujwx4j3BkJ8fDxmzZqF2tpaTJo0CUOHDm1jv7Rm2y9LmTrKYkMBADw8PIT2W7duQavVGocOV69exaFDh5CamgoAGDlyJDw9PZGfn9+9Bd/Dwc4ZAHDz1g2hvf52DRzsXaQoySrZ2NggLS0NALBq1aoOLdNWINy8eRNVVVXYtm0bAGDOnDlmq/lhYJGh4O7uDgAoKysT2tesWYOqqirjScaKigr069fP2GsAgMGDB+PixYsmt2EwGLpkUqtjWq3bqYcb+roNxNnLx41tVdfK0XC7Fr79Q1rNb03U6pguO3atj6U4VBw2bBj69u2Ls2fP4ssvvzRZW3uB0OLtt98GAIwZM6aN/VKbbb8sZeooizzR6Ovri5CQEGRmZqJXr14YMGAAcnJykJeXBwAW/8kDAMRHp+MdzWqE+sfCxaE3/pG3GJGB4+HRy0fq0qxGy+/5yJEjJuc1FQgAUFJSgjt37iAwMBDOzs6oq6szS93WziJ7CnK5HLt27YJKpcLcuXORkpICd3d3ZGRkQKFQGE8yDhw4EFeuXMGdO3eMy54/fx6DBkl/dj8xdgmih0zC/A1RSHplAPR6HZZM3y51WVbF09MTAO572TLQsUAAgMbGRlRUVEAul7camtIPZIbO9CsklpycjJKSEpw8edLYNm7cOEyePBnz5s1DQUEBEhIScOHCBdja2nZLTUU7H63bsbl5AZGJ5ll3TEyMcLLRxsYGDg4OaG5uRkNDQ7vLRUZGYv/+/Th58qTJ6xDc3NzQ1NSEhoYGoUutVqt5leP3LHL40J6ioiJER0cLbZs2bcLMmTORlZUFW1tb7Nixo9sCgcyrubkZtbWmP60pKirC6NGjUV5ebvIahJqami6q7uFlNaFQX1+PsrIyzJs3T2j39fUVvvRCj6ZTp05JXcJDw2pCwcnJCTqdTuoyiB56FnmikYikw1AgIgFDgYgEDAUiEjAUiEjAUCAigdV8JEkPv7CwsE4vU15RBQDwHdhfeN0d235YMRTIYjzIo+CXrN4MAFi1OF14TQ+OwwciEjAUrNSkpU44fcH0PQaIOouhIIFfZ/rg02Otv0bdXntbPny1HsE+jwMASs5pMH4xR4LUNRgKBABo1jVJXQJZCIaCBdpXuBUzVvlj96HXkPSKF375Yk9k5cyGTv/DF8KefF6G0vOHcPXGN/hT9lPQ63WYtNQJk5Y64ZOiu/ciXPtOCqa/4o2n/+yM1LXB+PzE/xqXb+ld7D/2NpL/4otnXuqFDws2YvZfQ4Vavrl6DuMX2+DKddO3uKOHA/ucFurK9Yu4XncF25acQ3XNJfz2tREY5jsaY8J/Jczn7uqJzLS9+OPmsfjw1XrhvaGDR2H2xHVw7OGGAyd3Yc3O38DPMwyD+gUDAPR6HY6eycOmhSegUCih0zdj857n8c9LhQjyjgIA7C3cgnD/sXxWxSOEPQULZafsgRnjX4atjR0GuPsjLGAMyiqLOrWOp0akwsWxNxRyBWLDEjG4fwhKzmmEeWbFr4ZjD1fY2zrA0d4FMWGJ2Ht0C4C7j77bX7QN8Y/N6qrdIivAnoIEFAolmvWtx/DNuibYfP8/tptTXyjkCuN79kpH4/MkOkKv1+O/9y+HtuQdfFf3b8ggw+3Gm7hRX22cRy6To4+bt7DcxOjZ+OPmsZgz6a84cfYz6PTNeFz19APsJVkrhoIEPHr64JurZ4W2W3fqcb3u3+jf2xcX/v1Vp9Ynk7Xu8OUX78Deo9lYNesTDOobDLlcjnkbImGA4ccLtnpISJB3FDx7++HAyV34onQ3xkXOhI1CCXp0cPgggXGRM5F3ZDNOlR+ETq9DXcN1vP7+Avh4DIO/5/BOr6+Xswf0eh2qvjtvbGu4XQuF3AZujn1gMOjx8dE3Ud7BR9bFP5aOHO16HD2Th6dGpHW6HrJu7ClIYEz4r3CnqQF/252BKzUX0cPWCSG+aqx87kMoFJ3/lXj1CcSkx+fit6+NQLOuCRmT/4YnI2fgxLnPMWO1P+yUDhgbnoxhg3/RsfqG/wr/2PM8VD4/h1efgE7XQ9bNqm7xbokexlu8GwwG/OYvvkh56lU8MXy68J45b/H+IPjdh67H4QO18tnx/0GTrhG/GJYgdSkkAQ4fSJCwvA8UchssmvomlDZ8fkZHLFy4EMXFxd2+3bCwsAf6ZqkpDAUS5CyvNj0TCYqLi4UnW1k7Dh+ISMBQICIBQ4GIBAwFIhIwFIhIwFAgIgFDgcgKuLq6dtu2eJ0CUTcKDg7GpEmTEBERAT8/PyiVSty4cQPFxcU4fPgwdu/ejYaGBmGZ8PBw7Nu3D3/4wx+wbds2s9fIUCDqBqNGjcLKlSsRExPT7vvz58/HjRs3kJ2djRUrVqCurg7h4eH49NNP0bNnT0ycOLFbQsGihw96vR7r1q1DQEAA7O3tERoaCq1Wi6CgIKSn80svZPmUSiWysrKg1WoRExODuro6ZGdnY8aMGYiKikJoaCjGjh2LxYsXo6CgAK6urli0aBFKS0uRnp5uDITc3FxMnz7d9Aa7gEX3FFJTU5Gbm4tly5YhIiICBQUFSEpKQnV1NX7/+99LXV678ot34oOC/0L5NyW43dSAfaubpS6JJGBra4vdu3cjPj4ezc3NePXVV7F27VrU1bW+g9Znn32GNWvWICIiAhs3bkRUVBQ2bdoEmUyG3NxcJCYmoqmpe+64bbGhsGPHDmzduhUajQZqtRoAEBsbi+PHjyM3Nxfh4eESV9g+px49MenxeWhsuoX/fJc9mkfVG2+8gfj4eFRXV2PChAkoLCw0ucyxY8eQkZGBAwcOwN7eHjqdDmvXru22QAAsePiQmZmJuLg4YyC08Pf3h1KpREhICADgxRdfRGBgIORyOXJycqQotZWooPF4YngS+vf2lboUksjTTz+NmTNnoqGhAWPHju1QIAA/nFS0t7dHeXk5FAoFsrOzYWdnZ+aKf2CRoVBZWYnS0lJMmTKl1XsVFRVQqVTGgxQXF4ePP/4Yo0eP7tQ2ZN/fn/CnTlqtpit22WpotZouO3ZdMbW493V3Tvd+Q1Iul2PDhg0AgCVLluDkyZMdOrY/PqmYm5uLsLAwnDlzBiqVCnPnzm3jd6F9oGNlisWGAgB4eHgI7bdu3YJWqxWGDiNHjoSvL/9HJssxYcIE+Pj44OzZs/j73//eoWXuDYTExETU1dVhyZIlAIC5c+d26g/7p7DIUHB3dwcAlJWVCe1r1qxBVVUVIiIifvI2DAZDl0xqdcxPrsWaqNUxXXbsumJqce/r7pzuHeImJSUBuHtOoSN3O2wrEFrOIXz00Ue4dOkSAgMDW51HU6vVD3SsTLHIE42+vr4ICQlBZmYmevXqhQEDBiAnJwd5eXkA0CWhQGQukZGRAID9+/ebnPd+gQAAOp0OGo0GycnJiIyMxLFjx8xWdwuL7CnI5XLs2rXLOJZKSUmBu7s7MjIyoFAojCcZLZVOr0Nj0200NTcCABqbbqOx6Xan0pqsk62tLQICAtDc3Iyvvrr/8ztMBUKLllu9qVQqc5TcikX2FAAgMDAQ+fn5QltycjKCg4PRo0cPiarqmE+PvY11/5di/HnCn+7W+/YL5+HRy0eiqqi7vPTSS5DJZGhubv/6FBsbG+Tk5JgMBAA4ePAgVq5ciSNHjpirZLG2btlKFykqKkJ0dLTQtmzZMrz11luorq7GqVOnsHDhQmi1Wvj5+UlUJTA+aibGR82UbPskncbGRrz88ssm52tubsa0adMwb948pKen3/c6hMLCwg5/pNkVLHL40Jb6+nqUlZW1OtmycuVKVFZW4s6dO7h27RoqKyslDQSijiosLERKSkq3XpjUEVbTU3BycoJOp5O6DKKHntX0FIioezAUiEjAUCAiAUOBiAQMBSISMBSISMBQICKB1VynYKmc+0pdQfd61Pa3I8LCwjq9THlFFQDAd2B/4bW5t9sRDIWfKOgJqSsgqWVlZXV6mSWrNwMAVi1OF15bAg4fiEjAUCAiAUOBiAQMBSISMBSISMBQICIBQ4GIBAwFIhIwFIhIwFAgIgFDgYgEDAUiEjAUiEjAUCAiAUOBiAQMhTZcunQJY8aMwZAhQ6BSqfDCCy9IXRKZiUajgUqlgr+/P9LS0qzigUMLFiyAl5cXbGzMczsUhkIbbGxssHr1anz99dc4ceIEDh06hPfff1/qsqiL6fV6pKWlYdeuXTh79ixqa2uxfft2qcsyacqUKSgqKjLb+hkKbejfvz8iIyMB3H20+PDhw1FRUSFxVdTVCgsL4enpieDgYABAamoq3n33XYmrMm3UqFHw8PAw2/p5OzYTvvvuO7z33nv45JNPpC6FAOgNBrzz4ef49lqN0L7hrXfbfD0qahgihga2ua7Kykp4e3sbfx44cCAuXbrUtQV/78y5Cuw70PrJ0W3V7eLkgORfjoONjcIstZjCnsJ9NDY2IiEhAQsWLMDPfvYzqcshAHKZDKNHhOLK1e9Q9e01Y/u9r6u+vQaZDAgd0v4TyA0Gg1lr/bEgX284OfQw1tairbpHRgyVLBAAhkK7dDodpk+fjrCwMCxatEjqcuhHBni4Y+zPI+47j41CgWkTn4CNov0/Lm9vb6FnUFFRAS8vry6r88dkMhkS4tXoYW933/mihwcjyNf7vvOYG0OhHenp6XB2dsb69eulLoXaoI4Ow0DP9u83H6cegX7uPe+7jsjISFRWVuL06dMAgC1btuCZZ57p0jp/zNXZEZPHjWr3ffeeroiPecxs2+8ohkIbvvjiC7z55psoKirC8OHDERYWhtdeew1A93Y5qX0KuRxTJ8ZCqWx9WsxvkCdGRg41vQ6FAtnZ2UhISICfnx+cnJyQnJxsjnKNQof4ISzYv1W7XCbD1ImxsLVVmlzH7Nmz4eXlBZ1OBy8vL2RkZHRpjTID/5V3ygefFkCn02HyuFGQyWRSl/PIO1J8Grv3HTL+bG9ni4XPJcDNxUnCqu6v4fYdZG3JQW39TWPbmJHhePIXkRJW9QP2FDqhprYeR4pPw2AwMBAsxIjQIcIY/D+e/LlFBwIAONjbYcoEtfFnL48+eGJkuIQViaw+FE6dOoVnn30W7u7usLe3R0BAAJYuXWqWbWkOF8NgMCD28eFmWT91nkwmQ8JTajj0sMOwoMFtds0tUYCPl/FThqkTY6FQWM6folUPH44dO4bRo0fD29sbixcvxqBBg3D+/HkUFBRgy5Yt91225VFdRI+Kjj6WzqovXlq0aBEcHR1x5MgRuLq6GttTU1MlrIrIulltT6GhoQHOzs6YP38+NmzYYNZt1dTWY+3mnYgYGohn4kabdVtEUrPansL169eh1+sf+GKTBxk+HC05g6MlZx5oe0RS6+jwwXLObnRSz549IZfLcfnyZalLIXqoWO3wAQBiY2Nx+vRp/Otf/4KLi4tZtvHeJ4dwtORrPJ+eiJ6uzmbZBpElsdqeAgCsW7cO9fX1iI6OxtatW5Gfn49t27YhLS2tS9ZfU1uPwpNnEDksiIFAjwyrPacAABEREfjyyy+xbNky/O53v8Pt27fh7e2NxMTELln/tZpaODs68LoEeqRY9fChO+j1esjlVt2hIuoUhgIRCfhfIBEJGApEJGAoEJGAoUBEAoYCEQkYCkQkYCgQkYChQEQChgIRCRgKRCRgKBCRgKFARAKGAhEJGApEJGAoEJGAoUBEAoYCEQkYCkQkYCgQkYChQEQChgIRCRgKRCRgKBCRgKFARAKGAhEJGApEJGAoEJHg/wEMV9NOIG/p8gAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<Figure size 418.992x204.68 with 1 Axes>"
+       "<Figure size 327.252x204.68 with 1 Axes>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Create an operator\n",
-    "XX = Operator(Pauli(label='XX'))\n",
+    "XX = Operator(Pauli('XX'))\n",
     "\n",
     "# Add to a circuit\n",
     "circ = QuantumCircuit(2, 2)\n",
@@ -503,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -512,7 +512,7 @@
        "{'11': 1024}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -526,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:12.017240Z",
@@ -537,25 +537,25 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"word-wrap: normal;white-space: pre;background: #fff0;line-height: 1.1;font-family: &quot;Courier New&quot;,Courier,monospace\">     ┌───────────┐┌─┐   \n",
-       "q_0: ┤0          ├┤M├───\n",
-       "     │  Pauli:XX │└╥┘┌─┐\n",
-       "q_1: ┤1          ├─╫─┤M├\n",
-       "     └───────────┘ ║ └╥┘\n",
-       "c: 2/══════════════╩══╩═\n",
-       "                   0  1 </pre>"
+       "<pre style=\"word-wrap: normal;white-space: pre;background: #fff0;line-height: 1.1;font-family: &quot;Courier New&quot;,Courier,monospace\">     ┌────────────┐┌─┐   \n",
+       "q_0: ┤0           ├┤M├───\n",
+       "     │  Pauli(XX) │└╥┘┌─┐\n",
+       "q_1: ┤1           ├─╫─┤M├\n",
+       "     └────────────┘ ║ └╥┘\n",
+       "c: 2/═══════════════╩══╩═\n",
+       "                    0  1 </pre>"
       ],
       "text/plain": [
-       "     ┌───────────┐┌─┐   \n",
-       "q_0: ┤0          ├┤M├───\n",
-       "     │  Pauli:XX │└╥┘┌─┐\n",
-       "q_1: ┤1          ├─╫─┤M├\n",
-       "     └───────────┘ ║ └╥┘\n",
-       "c: 2/══════════════╩══╩═\n",
-       "                   0  1 "
+       "     ┌────────────┐┌─┐   \n",
+       "q_0: ┤0           ├┤M├───\n",
+       "     │  Pauli(XX) │└╥┘┌─┐\n",
+       "q_1: ┤1           ├─╫─┤M├\n",
+       "     └────────────┘ ║ └╥┘\n",
+       "c: 2/═══════════════╩══╩═\n",
+       "                    0  1 "
       ]
      },
-     "execution_count": 24,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -563,7 +563,7 @@
    "source": [
     "# Add to a circuit\n",
     "circ2 = QuantumCircuit(2, 2)\n",
-    "circ2.append(Pauli(label='XX'), [0, 1])\n",
+    "circ2.append(Pauli('XX'), [0, 1])\n",
     "circ2.measure([0,1], [0,1])\n",
     "circ2.draw()"
    ]
@@ -583,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:14.208734Z",
@@ -601,14 +601,14 @@
        "         input_dims=(2, 2), output_dims=(2, 2))"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "A = Operator(Pauli(label='X'))\n",
-    "B = Operator(Pauli(label='Z'))\n",
+    "A = Operator(Pauli('X'))\n",
+    "B = Operator(Pauli('Z'))\n",
     "A.tensor(B)"
    ]
   },
@@ -623,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 18,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:14.899024Z",
@@ -641,14 +641,14 @@
        "         input_dims=(2, 2), output_dims=(2, 2))"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "A = Operator(Pauli(label='X'))\n",
-    "B = Operator(Pauli(label='Z'))\n",
+    "A = Operator(Pauli('X'))\n",
+    "B = Operator(Pauli('Z'))\n",
     "A.expand(B)"
    ]
   },
@@ -663,7 +663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 19,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:15.655155Z",
@@ -679,14 +679,14 @@
        "         input_dims=(2,), output_dims=(2,))"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "A = Operator(Pauli(label='X'))\n",
-    "B = Operator(Pauli(label='Z'))\n",
+    "A = Operator(Pauli('X'))\n",
+    "B = Operator(Pauli('Z'))\n",
     "A.compose(B)"
    ]
   },
@@ -699,7 +699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 20,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:16.460560Z",
@@ -715,14 +715,14 @@
        "         input_dims=(2,), output_dims=(2,))"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "A = Operator(Pauli(label='X'))\n",
-    "B = Operator(Pauli(label='Z'))\n",
+    "A = Operator(Pauli('X'))\n",
+    "B = Operator(Pauli('Z'))\n",
     "A.compose(B, front=True)"
    ]
   },
@@ -741,7 +741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:17.113510Z",
@@ -771,7 +771,7 @@
        "         input_dims=(2, 2, 2), output_dims=(2, 2, 2))"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -779,13 +779,13 @@
    "source": [
     "# Compose XZ with an 3-qubit identity operator\n",
     "op = Operator(np.eye(2 ** 3))\n",
-    "XZ = Operator(Pauli(label='XZ'))\n",
+    "XZ = Operator(Pauli('XZ'))\n",
     "op.compose(XZ, qargs=[0, 2])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 22,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:17.324353Z",
@@ -815,7 +815,7 @@
        "         input_dims=(2, 2, 2), output_dims=(2, 2, 2))"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -823,7 +823,7 @@
    "source": [
     "# Compose YX in front of the previous operator\n",
     "op = Operator(np.eye(2 ** 3))\n",
-    "YX = Operator(Pauli(label='YX'))\n",
+    "YX = Operator(Pauli('YX'))\n",
     "op.compose(XZ, qargs=[0, 2], front=True)"
    ]
   },
@@ -838,7 +838,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 23,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:18.829988Z",
@@ -856,15 +856,15 @@
        "         input_dims=(2, 2), output_dims=(2, 2))"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "XX = Operator(Pauli(label='XX'))\n",
-    "YY = Operator(Pauli(label='YY'))\n",
-    "ZZ = Operator(Pauli(label='ZZ'))\n",
+    "XX = Operator(Pauli('XX'))\n",
+    "YY = Operator(Pauli('YY'))\n",
+    "ZZ = Operator(Pauli('ZZ'))\n",
     "\n",
     "op = 0.5 * (XX + YY - 3 * ZZ)\n",
     "op"
@@ -879,7 +879,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 24,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:19.151814Z",
@@ -893,7 +893,7 @@
        "False"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -913,7 +913,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:20.045005Z",
@@ -929,7 +929,7 @@
        "         input_dims=(2,), output_dims=(2,))"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -950,7 +950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 26,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:20.821642Z",
@@ -964,13 +964,13 @@
        "True"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "Operator(Pauli(label='X')) == Operator(XGate())"
+    "Operator(Pauli('X')) == Operator(XGate())"
    ]
   },
   {
@@ -982,7 +982,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 27,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:21.146256Z",
@@ -996,7 +996,7 @@
        "False"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1016,7 +1016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 28,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:22.171481Z",
@@ -1051,7 +1051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 29,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-08-21T09:04:44.743744Z",
@@ -1062,8 +1062,7 @@
     {
      "data": {
       "text/html": [
-       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td>Qiskit</td><td>None</td></tr><tr><td>Terra</td><td>0.14.0</td></tr><tr><td>Aer</td><td>0.6.0</td></tr><tr><td>Ignis</td><td>0.3.0</td></tr><tr><td>Aqua</td><td>0.7.0</td></tr><tr><td>IBM Q Provider</td><td>0.6.1</td></tr><tr><th>System information</th></tr><tr><td>Python</td><td>3.7.7 (default, Mar 26 2020, 10:32:53) \n",
-       "[Clang 4.0.1 (tags/RELEASE_401/final)]</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>4</td></tr><tr><td>Memory (Gb)</td><td>16.0</td></tr><tr><td colspan='2'>Wed Apr 29 12:36:22 2020 EDT</td></tr></table>"
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.20.2</td></tr><tr><td><code>qiskit-aer</code></td><td>0.10.4</td></tr><tr><td><code>qiskit-ignis</code></td><td>0.7.1</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.1</td></tr><tr><td><code>qiskit</code></td><td>0.36.2</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.9.9</td></tr><tr><td>Python compiler</td><td>GCC 11.1.0</td></tr><tr><td>Python build</td><td>main, Dec 29 2021 22:19:36</td></tr><tr><td>OS</td><td>Linux</td></tr><tr><td>CPUs</td><td>32</td></tr><tr><td>Memory (Gb)</td><td>125.64821243286133</td></tr><tr><td colspan='2'>Wed Jun 22 15:52:11 2022 EDT</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1075,7 +1074,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='width: 100%; background-color:#d5d9e0;padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'><h3>This code is a part of Qiskit</h3><p>&copy; Copyright IBM 2017, 2020.</p><p>This code is licensed under the Apache License, Version 2.0. You may<br>obtain a copy of this license in the LICENSE.txt file in the root directory<br> of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.<p>Any modifications or derivative works of this code must retain this<br>copyright notice, and modified files need to carry a notice indicating<br>that they have been altered from the originals.</p></div>"
+       "<div style='width: 100%; background-color:#d5d9e0;padding-left: 10px; padding-bottom: 10px; padding-right: 10px; padding-top: 5px'><h3>This code is a part of Qiskit</h3><p>&copy; Copyright IBM 2017, 2022.</p><p>This code is licensed under the Apache License, Version 2.0. You may<br>obtain a copy of this license in the LICENSE.txt file in the root directory<br> of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.<p>Any modifications or derivative works of this code must retain this<br>copyright notice, and modified files need to carry a notice indicating<br>that they have been altered from the originals.</p></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1103,7 +1102,7 @@
   "anaconda-cloud": {},
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1117,7 +1116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.9.9"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the operator tutorial to avoid the deprecated Pauli
constructor kwarg, label. This has been deprecated since Qiskit Terra
0.17.0 and is pending removal in Qiskit/qiskit-terra#8070. The label
kwarg isn't needed anymore as the Pauli string can just be input
directly as the first positional argument and the Pauli object will be
created just as with the label kwarg before.

### Details and comments