### PR TITLE
Small fix in the text: "execute" -> "run"

### DIFF
--- a/tutorials/circuits/1_getting_started_with_qiskit.ipynb
+++ b/tutorials/circuits/1_getting_started_with_qiskit.ipynb
@@ -209,7 +209,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have chosen the backend, it's time to compile and run the quantum circuit. In Qiskit we provide the `execute` function for this. ``execute`` returns a ``job`` object that encapsulates information about the job submitted to the backend.\n",
+    "Now that we have chosen the backend, it's time to compile and run the quantum circuit. In Qiskit we provide the `run` function for this. ``run`` returns a ``job`` object that encapsulates information about the job submitted to the backend.\n",
     "\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",


### PR DESCRIPTION
Small fix in tutorial 1_getting_started_with_qiskit. In the code cell is correctly used the "run" function instead of the "execute" function, but in the markdown text above the cell code remained the "execute" function

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Small fix in tutorial 1_getting_started_with_qiskit.
In the code cell is correctly used the "run" function instead of the "execute" function, but in the markdown text above the cell code remained the "execute" function.


### Details and comments
see above

