### PR TITLE
Error on Sphinx warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
 
 [testenv:docs]
 commands =
-  sphinx-build -j auto -b html {toxinidir} {toxinidir}/_build/html/
+  sphinx-build -W --keep-going -j auto -b html {toxinidir} {toxinidir}/_build/html/
 
 [testenv:docs-clean]
 deps =

--- a/tutorials/algorithms/07_grover_examples.ipynb
+++ b/tutorials/algorithms/07_grover_examples.ipynb
@@ -142,11 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "tags": [
-     "nbsphinx-thumbnail"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from qiskit.tools.visualization import plot_histogram\n",

--- a/tutorials/operators/02_gradients_framework.ipynb
+++ b/tutorials/operators/02_gradients_framework.ipynb
@@ -662,7 +662,7 @@
    "source": [
     "### Natural Gradient\n",
     "\n",
-    "A special type of first order gradient is the natural gradient which has proven itself useful in classical machine learning and is already being studied in the quantum context. This quantity represents a gradient that is 'rescaled' with the inverse [Quantum Fisher Information matrix](#qfi) (QFI)\n",
+    "A special type of first order gradient is the natural gradient which has proven itself useful in classical machine learning and is already being studied in the quantum context. This quantity represents a gradient that is 'rescaled' with the inverse [Quantum Fisher Information matrix](#Quantum-Fisher-Information-(QFI)) (QFI)\n",
     "$$ QFI ^{-1} \\frac{\\partial\\langle\\psi\\left(\\theta\\right)|\\hat{O}\\left(\\omega\\right)|\\psi\\left(\\theta\\right)\\rangle}{\\partial\\theta}.$$"
    ]
   },


### PR DESCRIPTION
There were two issues preventing this:

1. nbsphinx changed how it does in-page URLs now for `#` anchors.
2. Grover Examples has had a bad thumbnail. I thought it would be fixed by https://github.com/Qiskit/qiskit-tutorials/pull/1466, but the error still exists, so I think this has always been an issue.

