### PR TITLE
Clarification of scope of optimal_num_iterations.

### DIFF
--- a/tutorials/algorithms/06_grover.ipynb
+++ b/tutorials/algorithms/06_grover.ipynb
@@ -627,7 +627,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When the number of solutions is known, we can also use a static method `optimal_num_iterations` to find the optimal number of iterations. Note that the output iterations is an approximate value. When the number of qubits is small, the output iterations may not be optimal.\n"
+    "When the number of solutions is known, we can also use a static method `optimal_num_iterations` to find the optimal number of iterations. Note that the output iterations is an approximate value. When the number of qubits is small, the output iterations may not be optimal. In addition, the calculation of this value assumes the standard uniform superposition state preparation and may not be accurate for other state preparations.\n"
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Quick change to Grover's Algorithm tutorial to clarify that `optimal_num_iterations` is designed for the uniform superposition and not general state preparations.

### Details and comments

Change was inspired by [this Quantum Computing StackExchange question](https://quantumcomputing.stackexchange.com/questions/32951/find-the-number-of-iterations-for-amplitude-amplification-to-get-the-correct-sta).
