### PR TITLE
Fix VQE tutorial to point to Aer docs

### DIFF
--- a/tutorials/algorithms/03_vqe_simulation_with_noise.ipynb
+++ b/tutorials/algorithms/03_vqe_simulation_with_noise.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This notebook demonstrates how to leverage the [Qiskit Aer Primitives](https://qiskit.org/documentation/apidoc/aer_primitives.html) to run both noiseless and noisy simulations locally. Qiskit Aer not only allows you to define your own custom noise model, but also to easily create a noise model based on the properties of a real quantum device. This notebook will show an example of the latter, to illustrate the general workflow of running algorithms with local noisy simulators.\n",
     "\n",
-    "For further information on the Qiskit Aer noise model, you can consult the [Qiskit Aer documentation](https://qiskit.org/documentation/apidoc/aer_noise.html), as well the tutorial for [building noise models](../simulators/3_building_noise_models.ipynb)."
+    "For further information on the Qiskit Aer noise model, you can consult the [Qiskit Aer documentation](https://qiskit.org/ecosystem/aer/apidocs/aer_noise.html), as well the tutorial for [building noise models](https://qiskit.org/ecosystem/aer/tutorials/3_building_noise_models.html)."
    ]
   },
   {


### PR DESCRIPTION
This is necessary to unblock https://github.com/Qiskit/qiskit-tutorials/pull/1489 and https://github.com/Qiskit/qiskit-metapackage/pull/1776.