### PR TITLE
Fix unit sphere notation in 3_summary_of_quantum_operations.ipynb

### DIFF
--- a/tutorials/circuits/3_summary_of_quantum_operations.ipynb
+++ b/tutorials/circuits/3_summary_of_quantum_operations.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "$$\\left|\\psi\\right\\rangle = \\cos(\\theta/2)\\left|0\\right\\rangle + \\sin(\\theta/2)e^{i\\phi}\\left|1\\right\\rangle$$\n",
     "\n",
-    "where $0\\leq \\phi < 2\\pi$, and $0\\leq \\theta \\leq \\pi$.  From this, it is clear that there is a one-to-one correspondence between qubit states ($\\mathbb{C}^2$) and the points on the surface of a unit sphere ($\\mathbb{R}^3$). This is called the Bloch sphere representation of a qubit state.\n",
+    "where $0\\leq \\phi < 2\\pi$, and $0\\leq \\theta \\leq \\pi$.  From this, it is clear that there is a one-to-one correspondence between qubit states ($\\mathbb{C}^2$) and the points on the surface of a unit sphere ($\\mathbb{S}^2$). This is called the Bloch sphere representation of a qubit state.\n",
     "\n",
     "Quantum gates/operations are usually represented as matrices. A gate which acts on a qubit is represented by a $2\\times 2$ unitary matrix $U$. The action of the quantum gate is found by multiplying the matrix representing the gate with the vector which represents the quantum state.\n",
     "\n",


### PR DESCRIPTION
Change the unit sphere notation to $\\mathbb{S}^2$